### PR TITLE
Improve grammar for "session ticket support", and homogenize language usage to "Your client...".

### DIFF
--- a/static/about.html
+++ b/static/about.html
@@ -196,17 +196,18 @@
 
         <h4 class="fragpadded" id="session-ticket-support">Session Ticket Support</h4>
         <p>Session tickets are a mechanism to speed up resumption of encrypted
-          communication with a server. When a client and server first connect
-          over TLS, they perform a complicated, time-consuming handshake. This
-          handshake lets the client and the server communicate a shared secret
-          (basically, a password) without exposing that secret to people
-          tapping the line. However, it only allows the client and the
-          specific computer that served the client communicate. Since websites
-          can (and, often, must) serve their traffic from many physical
-          computers, if the client disconnects and reconnects to the website,
-          the client could connect to another machine that knew nothing about
-          the shared secret. When that happens, the client and server have to
-          perform the slow handshake again.</p>
+          communication with a server. When a client and server first
+          connect over TLS, they perform a complicated, time-consuming
+          handshake.  This handshake lets the client and the server
+          communicate a shared secret (basically, a password) without
+          exposing that secret to people tapping the line.  However, it only
+          allows the client and the specific computer that served the client
+          to communicate.  Since websites can (and, often, must) serve their
+          traffic from many physical computers, if the client disconnects
+          and reconnects to the website, the client could connect to another
+          machine that knew nothing about the shared secret.  When that
+          happens, the client and server have to perform the slow handshake
+          again.</p>
         <p>If the client supports session tickets, the physical machines that
           serve a website's traffic and share a special second key called a
           session ticket key can deterministically generate a secret shared

--- a/templates/index.html
+++ b/templates/index.html
@@ -124,15 +124,15 @@
         <div class="span4">
           <h2>Session Ticket Support</h2>
           {{if .SessionTicketsSupported}}
-          <p><span class="label okay">Good</span> Session tickets are supported in
-            your client. Services you use will be able to scale out their TLS
-            connections much easier with this feature.</p>
+          <p><span class="label okay">Good</span> Your TLS client supports
+            session tickets.  Services you use will be able to scale out
+            their TLS infrastructure much more easily with this feature.</p>
           {{else}}
-          <p><span class="label improvable">Improvable</span> Session tickets are
-            not supported in your client. Without them, it'll take your
-            connections over TLS longer to work and its harder for services to
-            scale out. Generally, clients with ephemeral key support gets this
-            for free.</p>
+          <p><span class="label improvable">Improvable</span> Your TLS
+            client does not support session tickets.  Without them, it can
+            TLS connections longer to start up, and it's harder for services
+            you use to scale.  Generally, clients with ephemeral key support
+            gets this for free.</p>
           {{end}}
           <p><a href="/s/about.html/#session-ticket-support">Learn More</a></p>
         </div>


### PR DESCRIPTION
I took a grammar OCD exception on the text for "Session Ticket Support", so I cleaned it up a little bit.