### PR TITLE
Fix link to "What it means" section on About page

### DIFF
--- a/static/api.html
+++ b/static/api.html
@@ -100,8 +100,8 @@
         </pre></p>
         <p>The returned JSON hash will have a least these keys, but may
           include more as howsmyssl evolves. Each of these keys map fairly
-          obviously to the HTML version and the <a href="#what-it-means">
-          about its text can be helpful to understand their meaning. The
+          obviously to the HTML version and the <a href="about.html#what-it-means">
+          text</a> can be helpful to understand their meaning. The
           source code
           that <a href="https://github.com/jmhodges/howsmyssl/blob/master/client_info.go">gathers
           the client info</a> may also be helpful. All strings returned may


### PR DESCRIPTION
Noticed that this was wrong from reading the paragraph at https://www.howsmyssl.com/s/api.html
