### PR TITLE
SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA is not insecure

### DIFF
--- a/all_suites.go
+++ b/all_suites.go
@@ -329,3 +329,12 @@ var allCipherSuites = map[uint16]string{
 	0xCC14: "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
 	0xCC15: "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
 }
+
+// Obsolete cipher suites in NSS that were meant to die with SSL 3.0 but
+// 0xFEFF is still emitted by by Firefox 25.0. Discussed here:
+// https://groups.google.com/forum/#!topic/mozilla.dev.tech.crypto/oWk0FkKsek4
+// and
+// http://www-archive.mozilla.org/projects/security/pki/nss/ssl/fips-ssl-ciphersuites.html
+var weirdNSSSuites = map[uint16]string{
+	0xFEFF: "SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA",
+}

--- a/client_info.go
+++ b/client_info.go
@@ -59,7 +59,6 @@ func ClientInfo(c *conn) *clientInfo {
 				s = fmt.Sprintf("Some unknown cipher suite: %#x", ci)
 			} else {
 				s = w
-				d.InsecureCipherSuites[s] = append(d.InsecureCipherSuites[s], weirdNSSReason)
 			}
 		}
 		d.GivenCipherSuites = append(d.GivenCipherSuites, s)

--- a/insecure_suites.go
+++ b/insecure_suites.go
@@ -18,6 +18,7 @@ var (
 //   TLS_KRB5_EXPORT_WITH_RC4_40_SHA	     40-bit encryption, export grade
 //   TLS_KRB5_WITH_DES_CBC_MD5	             56-bit encryption
 //   TLS_KRB5_WITH_DES_CBC_SHA               56-bit encryption
+//   SSL_RSA_FIPS_WITH_DES_CBC_SHA           56-bit encryption
 var fewBitCipherSuites = map[string]bool{
 	"TLS_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA": true,
 	"TLS_DHE_DSS_WITH_DES_CBC_SHA":          true,
@@ -40,6 +41,7 @@ var fewBitCipherSuites = map[string]bool{
 	"TLS_KRB5_EXPORT_WITH_RC4_40_SHA":       true,
 	"TLS_KRB5_WITH_DES_CBC_MD5":             true,
 	"TLS_KRB5_WITH_DES_CBC_SHA":             true,
+	"SSL_RSA_FIPS_WITH_DES_CBC_SHA":         true,
 }
 
 // Cipher suites that offer no encryption.
@@ -111,14 +113,4 @@ var nullAuthCipherSuites = map[string]bool{
 	"TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA":        true,
 	"TLS_SRP_SHA_WITH_AES_128_CBC_SHA":         true,
 	"TLS_SRP_SHA_WITH_AES_256_CBC_SHA":         true,
-}
-
-// Obsolete cipher suites in NSS that were meant to die with SSL 3.0 but
-// 0xFEFF is still emitted by by Firefox 25.0. Discussed here:
-// https://groups.google.com/forum/#!topic/mozilla.dev.tech.crypto/oWk0FkKsek4
-// and
-// http://www-archive.mozilla.org/projects/security/pki/nss/ssl/fips-ssl-ciphersuites.html
-var weirdNSSSuites = map[uint16]string{
-	0xFEFE: "SSL_RSA_FIPS_WITH_DES_CBC_SHA",
-	0xFEFF: "SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA",
 }

--- a/static/about.html
+++ b/static/about.html
@@ -296,11 +296,6 @@
           SSL/TLS specifications even though offer no privacy or security for
           the user or the web service. These are giant, glowing "rob me" signs
           on the web.</p>
-        <p>Finally, a cipher suite can be added here if it is known to be
-          obsolete in some way. Currently, some NSS clients (like Firefox)
-          will allow for the use of under-specified or broken cipher suites
-          that were meant to be killed off after the death of SSLv3 and were
-          never really specified well in the first place.</p>
         <p>Any client supporting an insecure cipher suite will be marked as
           <span class="label bad">Bad</span>.</p>
 


### PR DESCRIPTION
SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA is exactly like SSL_RSA_WITH_3DES_EDE_CBC_SHA except for one difference when the handshake negotiates SSL 3.0: SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA will use the more secure TLS PRF, whereas SSL_RSA_WITH_3DES_EDE_CBC_SHA will use the less secure SSL 3.0 PRF. Consequently, at least in theory, SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA is more secure than SSL_RSA_WITH_3DES_EDE_CBC_SHA. Since SSL_RSA_WITH_3DES_EDE_CBC_SHA is considered "Probably okay" and SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA is more secure than that one, SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA should be considered "Probably okay" too.

In practice, no servers negotiate this cipher suite, and the browser that offers it (Firefox 26 and earlier) does not do TLS False Start, so it really doesn't matter in terms of security whether the browser supports the cipher suite or not.

Soon this will be a non-issue because Firefox 27 will stop offering the SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA cipher suite in its ClientHello.
