### PR TITLE
Replace "much easier" with "more easily"

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -133,7 +133,7 @@
           {{if .SessionTicketsSupported}}
           <p><span class="label okay">Good</span> Session tickets are supported in
             your client. Services you use will be able to scale out their TLS
-            connections much easier with this feature.</p>
+            connections more easily with this feature.</p>
           {{else}}
           <p><span class="label improvable">Improvable</span> Session tickets are
             not supported in your client. Without them, services will have a harder 


### PR DESCRIPTION
In this sentence, it is preferable to use an adverb ("easily") rather than an adjective ("easier").
