### PR TITLE
Rewrite HTTP URLs to HTTPS.

### DIFF
--- a/all_suites.go
+++ b/all_suites.go
@@ -2,7 +2,7 @@ package main
 
 // All cipher suites in the TLS standards.
 // Generated with:
-//   curl -s http://www.iana.org/assignments/tls-parameters/tls-parameters.txt | grep '0x.* TLS_' | awk '{ print $1":","\""$2"\","}' | sed 's/,0x//'
+//   curl -s https://www.iana.org/assignments/tls-parameters/tls-parameters.txt | grep '0x.* TLS_' | awk '{ print $1":","\""$2"\","}' | sed 's/,0x//'
 //
 // Plus appending the new ChaCha20/Poly1305 curve ciphers from Chrome 33.0 and
 // the fallback SCSV if the client had to degrade its version of TLS in order
@@ -329,7 +329,7 @@ var allCipherSuites = map[uint16]string{
 	0xCC14: "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
 	0xCC15: "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
 
-	// http://tools.ietf.org/html/draft-ietf-tls-56-bit-ciphersuites-01
+	// https://tools.ietf.org/html/draft-ietf-tls-56-bit-ciphersuites-01
 	0x0062: "TLS_RSA_EXPORT1024_WITH_DES_CBC_SHA",
 	0x0063: "TLS_DHE_DSS_EXPORT1024_WITH_DES_CBC_SHA",
 	0x0064: "TLS_RSA_EXPORT1024_WITH_RC4_56_SHA",

--- a/insecure_suites.go
+++ b/insecure_suites.go
@@ -20,7 +20,7 @@ var (
 //   TLS_KRB5_WITH_DES_CBC_MD5	             56-bit encryption
 //   TLS_KRB5_WITH_DES_CBC_SHA               56-bit encryption
 //
-// and, from http://tools.ietf.org/html/draft-ietf-tls-56-bit-ciphersuites-01:
+// and, from https://tools.ietf.org/html/draft-ietf-tls-56-bit-ciphersuites-01:
 //
 //   TLS_RSA_EXPORT1024_WITH_DES_CBC_SHA     56-bit encryption, export grade
 //   TLS_DHE_DSS_EXPORT1024_WITH_DES_CBC_SHA 56-bit encryption, export grade

--- a/static/about.html
+++ b/static/about.html
@@ -126,10 +126,10 @@
           <li>It supports TLS compression (that is compression of the
             encryption information used to secure your connection) which
             exposes it to the
-            <a href="http://en.wikipedia.org/wiki/CRIME_(security_exploit)">CRIME
+            <a href="https://en.wikipedia.org/wiki/CRIME_(security_exploit)">CRIME
               attack</a>.</li>
           <li>It is susceptible to the
-            <a href="http://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
+            <a href="https://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
             attack</a>.</li>
         </ul>
         <p>How's My SSL? always selects the worst rating the client could
@@ -176,7 +176,7 @@
           the service that it supports cipher suites that include an
           additional private key created for each connection to the
           service. This allows servers that support it to
-          provide <a href="http://en.wikipedia.org/wiki/Forward_secrecy">forward
+          provide <a href="https://en.wikipedia.org/wiki/Forward_secrecy">forward
           secrecy</a> to the client.</p>
         <p>This extra key prevents attackers from storing all of
           your encrypted communication with the website, then later
@@ -215,7 +215,7 @@
           attacker. Worse, it undermines the security
           of <a href="#ephemeral-key-support">ephemeral key cipher
           suites</a>. Preventing this is often a source
-          of <a href="http://googleonlinesecurity.blogspot.com/2011/11/protecting-data-for-long-term-with.html">important</a>
+          of <a href="https://googleonlinesecurity.blogspot.com/2011/11/protecting-data-for-long-term-with.html">important</a>
           <a href="https://blog.twitter.com/2013/forward-secrecy-at-twitter-0">engineering</a>
           <a href="https://www.imperialviolet.org/2013/06/27/botchingpfs.html">work</a>
           for a security engineer team. Of course, another alternative is for
@@ -234,7 +234,7 @@
           encrypted data if the attackers can make the user's computer make
           connections to the website. In practice, this turns out to be
           easy. This is now referred to as
-          the <a href="http://en.wikipedia.org/wiki/CRIME_(security_exploit)">CRIME
+          the <a href="https://en.wikipedia.org/wiki/CRIME_(security_exploit)">CRIME
           attack</a>. While some clients have mitigations in place, it's been
           determined that the best way to avoid the attack is to disable TLS 
           compression entirely. Clients that do so will be defaulted to 
@@ -243,11 +243,11 @@
           as <span class="label bad">Bad</span>.</p>
 
         <h4 class="fragpadded" id="beast-vulnerability">BEAST Vulnerability</h4>
-        <p>The <a href="http://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
+        <p>The <a href="https://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
         vulnerability</a> is an attack on TLS 1.0 connections using a
         cipher suite in a cipher block chaining (CBC) mode. An
         attacker is able
-        to <a href="http://vnhacker.blogspot.com/2011/09/beast.html">decrypt
+        to <a href="https://vnhacker.blogspot.com/2011/09/beast.html">decrypt
         the data</a> on a TLS connection matching that
         criteria. Upgrading to TLS 1.1 or greater or not using CBC
         cipher suites prevents the attack (though, RC4 has its own
@@ -294,7 +294,7 @@
           certificate. This is called the "certificate authority trust model",
           and if this sounds crazy to you on many levels, you are not
           alone. It's currently the best security we have,
-          however. <a href="http://tack.io/index.html">TACK</a> is one good
+          however. <a href="https://tack.io/index.html">TACK</a> is one good
           attempt to, in a backwards compatible way, replace it.</p>
         <p>A cipher suite may also be added if it's a "null cipher suite"
           which is a funny way of saying the cipher does not encrypt the data
@@ -336,10 +336,10 @@
         <p>Okay, last thing. The jargon around is a little funny, so
            let's be a little more explicit. The 'S' in "HTTPS" is the
            TLS protocol. When folks refer to the
-           "<a href="http://en.wikipedia.org/wiki/Transport_Layer_Security">TLS</a>"
+           "<a href="https://en.wikipedia.org/wiki/Transport_Layer_Security">TLS</a>"
            they are referring to the most common of modern protocols
            of encrypting data across the
-           internet. "<a href="http://en.wikipedia.org/wiki/SSL">SSL</a>",
+           internet. "<a href="https://en.wikipedia.org/wiki/SSL">SSL</a>",
            when used by experts, refers to the older versions of these
            protocols. In general, people use "SSL" and "TLS"
            interchangeably, but that's changing towards everyone
@@ -369,16 +369,16 @@
       <footer>
         <p class="muted credit">
             <a rel="license"
-               href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0"
+               href="https://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0"
                src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"
                /></a><br />This work is licensed under a <a rel="license"
-               href="http://creativecommons.org/licenses/by-sa/4.0/">Creative
+               href="https://creativecommons.org/licenses/by-sa/4.0/">Creative
                Commons Attribution-ShareAlike 4.0 International License</a>.
 
             <br />
 
             Written by
-            <a href="http://www.somethingsimilar.com/about/">Jeff Hodges</a></p>
+            <a href="https://www.somethingsimilar.com/about">Jeff Hodges</a></p>
       </footer>
     </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -111,7 +111,7 @@
           <p><span class="label okay">Good</span> Ephemeral keys are
             used in some of the cipher suites your client supports.
             This means your client may be used to provide
-            <a href="http://en.wikipedia.org/wiki/Forward_secrecy">forward
+            <a href="https://en.wikipedia.org/wiki/Forward_secrecy">forward
             secrecy</a> if the server supports it. This greatly increases your protection
             against snoopers, including global passive adversaries who
             scoop up large amounts of encrypted traffic and store
@@ -121,7 +121,7 @@
             Ephemeral keys are not used in any of the cipher suites
             your client supports. This means your client cannot be
             used to
-            provide <a href="http://en.wikipedia.org/wiki/Forward_secrecy">forward
+            provide <a href="https://en.wikipedia.org/wiki/Forward_secrecy">forward
             secrecy</a>. Without it, global passive adversaries will
             be able to scoop up all of your encrypted traffic and
             decode it when their attacks or their computers are
@@ -150,13 +150,13 @@
           <p><span class="label bad">Bad</span> Your TLS client supports
             compressing the settings that encrypt your connection. This is
             really not good. It makes your TLS connections susceptible to
-            the <a href="http://en.wikipedia.org/wiki/CRIME_(security_exploit)">CRIME
+            the <a href="https://en.wikipedia.org/wiki/CRIME_%28security_exploit%29">CRIME
             attack</a> and your encrypted data could be leaked!</p>
           {{else}}
           <p><span class="label okay">Good</span> Your TLS client does not attempt
             to compress the settings that encrypt your connection, avoiding
             information leaks from the
-            <a href="http://en.wikipedia.org/wiki/CRIME_(security_exploit)">CRIME
+            <a href="https://en.wikipedia.org/wiki/CRIME_%28security_exploit%29">CRIME
             attack</a>.</p>
           {{end}}
           <p><a href="/s/about.html/#tls-compression">Learn More</a></p>
@@ -168,10 +168,10 @@
             {{ if .AbleToDetectNMinusOneSplitting }}
 
             Your client is open to
-             the <a href="http://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
+             the <a href="https://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
              attack</a>. It's using TLS 1.0 or earlier while also
              supporting a cipher suite that
-             uses <a href="http://en.wikipedia.org/wiki/Cipher_block_chaining#Cipher-block_chaining_.28CBC.29">Cipher-Block
+             uses <a href="https://en.wikipedia.org/wiki/Cipher_block_chaining#Cipher-block_chaining_.28CBC.29">Cipher-Block
              Chaining</a> and doesn't implement the 1/n-1 record
              splitting mitigation. That combination will leak
              information.
@@ -179,10 +179,10 @@
             {{ else }}
 
             Your client is probably open to
-             the <a href="http://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
+             the <a href="https://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
              attack</a> because it's using TLS 1.0 or earlier while
              also supporting a cipher suite that
-             uses <a href="http://en.wikipedia.org/wiki/Cipher_block_chaining#Cipher-block_chaining_.28CBC.29">Cipher-Block
+             uses <a href="https://en.wikipedia.org/wiki/Cipher_block_chaining#Cipher-block_chaining_.28CBC.29">Cipher-Block
              Chaining</a>. However, the CBC cipher suites your client
              supports is not one How's My SSL is able to use, so it
              was unable to determine if your client implements the
@@ -198,20 +198,20 @@
             {{ if .AbleToDetectNMinusOneSplitting }}
 
             Your client is not vulnerable to
-            the <a href="http://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
+            the <a href="https://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
             attack</a>. While it's using TLS 1.0 in conjunction
-            with <a href="http://en.wikipedia.org/wiki/Cipher_block_chaining#Cipher-block_chaining_.28CBC.29">Cipher-Block
+            with <a href="https://en.wikipedia.org/wiki/Cipher_block_chaining#Cipher-block_chaining_.28CBC.29">Cipher-Block
             Chaining</a> cipher suites, it has implemented the 1/n-1
             record splitting mitigation.
 
             {{ else }}
 
             Your client is not vulnerable to
-            the <a href="http://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
+            the <a href="https://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
             attack</a> because it's using a TLS protocol newer than
             TLS 1.0. The BEAST attack is only possible against clients
             using TLS 1.0 or earlier
-            using <a href="http://en.wikipedia.org/wiki/Cipher_block_chaining#Cipher-block_chaining_.28CBC.29">Cipher-Block
+            using <a href="https://en.wikipedia.org/wiki/Cipher_block_chaining#Cipher-block_chaining_.28CBC.29">Cipher-Block
             Chaining</a> cipher suites that do not implement the
             1/n-1 record splitting mitigation.
 


### PR DESCRIPTION
I used HTTPS Everywhere's rewriter tool to fix up URLs wherever possible:
https://github.com/EFForg/https-everywhere/blob/master/rewriter/rewriter.js

I was mainly targetting the HTML. The comment changes are probably overzealous,
but the tool caught them, and might as well, right?