### PR TITLE
correctly gzip static files

### DIFF
--- a/gzip/LICENSE
+++ b/gzip/LICENSE
@@ -1,0 +1,12 @@
+Copyright (c) 2013, Martin Angers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of the author nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gzip/README.md
+++ b/gzip/README.md
@@ -1,0 +1,5 @@
+This code is from https://PuerkitoBio/ghost by Martin Angers. See
+LICENSE for licensing details.
+
+The ghost library includes many dependencies that are not in use in
+this codebase (e.g. redis), so we copied the relevant code instead.

--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -1,0 +1,168 @@
+package gzip
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+)
+
+// Thanks to Andrew Gerrand for inspiration:
+// https://groups.google.com/d/msg/golang-nuts/eVnTcMwNVjM/4vYU8id9Q2UJ
+//
+// Also, node's Connect library implementation of the compress middleware:
+// https://github.com/senchalabs/connect/blob/master/lib/middleware/compress.js
+//
+// And StackOverflow's explanation of Vary: Accept-Encoding header:
+// http://stackoverflow.com/questions/7848796/what-does-varyaccept-encoding-mean
+
+// Internal gzipped writer that satisfies both the (body) writer in gzipped format,
+// and maintains the rest of the ResponseWriter interface for header manipulation.
+type gzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+	r        *http.Request // Keep a hold of the Request, for the filter function
+	filtered bool          // Has the request been run through the filter function?
+	dogzip   bool          // Should we do GZIP compression for this request?
+	filterFn func(http.ResponseWriter, *http.Request) bool
+}
+
+// Make sure the filter function is applied.
+func (w *gzipResponseWriter) applyFilter() {
+	if !w.filtered {
+		if w.dogzip = w.filterFn(w, w.r); w.dogzip {
+			setGzipHeaders(w.Header())
+		}
+		w.filtered = true
+	}
+}
+
+// Unambiguous Write() implementation (otherwise both ResponseWriter and Writer
+// want to claim this method).
+func (w *gzipResponseWriter) Write(b []byte) (int, error) {
+	w.applyFilter()
+	if w.dogzip {
+		// Write compressed
+		return w.Writer.Write(b)
+	}
+	// Write uncompressed
+	return w.ResponseWriter.Write(b)
+}
+
+// Intercept the WriteHeader call to correctly set the GZIP headers.
+func (w *gzipResponseWriter) WriteHeader(code int) {
+	w.applyFilter()
+	w.ResponseWriter.WriteHeader(code)
+}
+
+// Implement WrapWriter interface
+func (w *gzipResponseWriter) WrappedWriter() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+var (
+	defaultFilterTypes = [...]string{
+		"text",
+		"javascript",
+		"json",
+	}
+)
+
+// Default filter to check if the response should be GZIPped.
+// By default, all text (html, css, xml, ...), javascript and json
+// content types are candidates for GZIP.
+func defaultFilter(w http.ResponseWriter, r *http.Request) bool {
+	hdr := w.Header()
+	for _, tp := range defaultFilterTypes {
+		ok := HeaderMatch(hdr, "Content-Type", HmContains, tp)
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+// GZIPHandlerFunc is the same as GZIPHandler, it is just a convenience
+// signature that accepts a func(http.ResponseWriter, *http.Request) instead of
+// a http.Handler interface. It saves the boilerplate http.HandlerFunc() cast.
+func GZIPHandlerFunc(h http.HandlerFunc, filterFn func(http.ResponseWriter, *http.Request) bool) http.HandlerFunc {
+	return GZIPHandler(h, filterFn)
+}
+
+// Gzip compression HTTP handler. If the client supports it, it compresses the response
+// written by the wrapped handler. The filter function is called when the response is about
+// to be written to determine if compression should be applied. If this argument is nil,
+// the default filter will GZIP only content types containing /json|text|javascript/.
+func GZIPHandler(h http.Handler, filterFn func(http.ResponseWriter, *http.Request) bool) http.HandlerFunc {
+	if filterFn == nil {
+		filterFn = defaultFilter
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := getGzipWriter(w); ok {
+			// Self-awareness, gzip handler is already set up
+			h.ServeHTTP(w, r)
+			return
+		}
+		hdr := w.Header()
+		setVaryHeader(hdr)
+
+		// Do nothing on a HEAD request
+		if r.Method == "HEAD" {
+			h.ServeHTTP(w, r)
+			return
+		}
+		if !acceptsGzip(r.Header) {
+			// No gzip support from the client, return uncompressed
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		// Prepare a gzip response container
+		gz := gzip.NewWriter(w)
+		gzw := &gzipResponseWriter{
+			Writer:         gz,
+			ResponseWriter: w,
+			r:              r,
+			filterFn:       filterFn,
+		}
+		h.ServeHTTP(gzw, r)
+		// Iff the handler completed successfully (no panic) and GZIP was indeed used, close the gzip writer,
+		// which seems to generate a Write to the underlying writer.
+		if gzw.dogzip {
+			gz.Close()
+		}
+	}
+}
+
+// Add the vary by "accept-encoding" header if it is not already set.
+func setVaryHeader(hdr http.Header) {
+	if !HeaderMatch(hdr, "Vary", HmContains, "accept-encoding") {
+		hdr.Add("Vary", "Accept-Encoding")
+	}
+}
+
+// Checks if the client accepts GZIP-encoded responses.
+func acceptsGzip(hdr http.Header) bool {
+	ok := HeaderMatch(hdr, "Accept-Encoding", HmContains, "gzip")
+	if !ok {
+		ok = HeaderMatch(hdr, "Accept-Encoding", HmEquals, "*")
+	}
+	return ok
+}
+
+func setGzipHeaders(hdr http.Header) {
+	// The content-type will be explicitly set somewhere down the path of handlers
+	hdr.Set("Content-Encoding", "gzip")
+	hdr.Del("Content-Length")
+}
+
+// Helper function to retrieve the gzip writer.
+func getGzipWriter(w http.ResponseWriter) (*gzipResponseWriter, bool) {
+	gz, ok := GetResponseWriter(w, func(tst http.ResponseWriter) bool {
+		_, ok := tst.(*gzipResponseWriter)
+		return ok
+	})
+	if ok {
+		return gz.(*gzipResponseWriter), true
+	}
+	return nil, false
+}

--- a/gzip/gzip_test.go
+++ b/gzip/gzip_test.go
@@ -1,0 +1,154 @@
+package gzip
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGzipped(t *testing.T) {
+	body := "This is the body"
+	headers := []string{"gzip", "*", "gzip, deflate, sdch"}
+
+	h := GZIPHandler(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			_, err := w.Write([]byte(body))
+			if err != nil {
+				panic(err)
+			}
+		}), nil)
+	s := httptest.NewServer(h)
+	defer s.Close()
+
+	for _, hdr := range headers {
+		t.Logf("running with Accept-Encoding header %s", hdr)
+		req, err := http.NewRequest("GET", s.URL, nil)
+		if err != nil {
+			panic(err)
+		}
+		req.Header.Set("Accept-Encoding", hdr)
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			panic(err)
+		}
+		assertStatus(http.StatusOK, res.StatusCode, t)
+		assertHeader("Content-Encoding", "gzip", res, t)
+		assertGzippedBody([]byte(body), res, t)
+	}
+}
+
+func TestNoGzip(t *testing.T) {
+	body := "This is the body"
+
+	h := GZIPHandler(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			_, err := w.Write([]byte(body))
+			if err != nil {
+				panic(err)
+			}
+		}), nil)
+	s := httptest.NewServer(h)
+	defer s.Close()
+
+	req, err := http.NewRequest("GET", s.URL, nil)
+	if err != nil {
+		panic(err)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	assertStatus(http.StatusOK, res.StatusCode, t)
+	assertHeader("Content-Encoding", "", res, t)
+	assertBody([]byte(body), res, t)
+}
+
+func TestNoGzipOnFilter(t *testing.T) {
+	body := "This is the body"
+
+	h := GZIPHandler(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "x/x")
+			_, err := w.Write([]byte(body))
+			if err != nil {
+				panic(err)
+			}
+		}), nil)
+	s := httptest.NewServer(h)
+	defer s.Close()
+
+	req, err := http.NewRequest("GET", s.URL, nil)
+	if err != nil {
+		panic(err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	assertStatus(http.StatusOK, res.StatusCode, t)
+	assertHeader("Content-Encoding", "", res, t)
+	assertBody([]byte(body), res, t)
+}
+
+func TestNoGzipOnCustomFilter(t *testing.T) {
+	body := "This is the body"
+
+	h := GZIPHandler(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			_, err := w.Write([]byte(body))
+			if err != nil {
+				panic(err)
+			}
+		}), func(w http.ResponseWriter, r *http.Request) bool {
+		return false
+	})
+	s := httptest.NewServer(h)
+	defer s.Close()
+
+	req, err := http.NewRequest("GET", s.URL, nil)
+	if err != nil {
+		panic(err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	assertStatus(http.StatusOK, res.StatusCode, t)
+	assertHeader("Content-Encoding", "", res, t)
+	assertBody([]byte(body), res, t)
+}
+
+func TestGzipOnCustomFilter(t *testing.T) {
+	body := "This is the body"
+
+	h := GZIPHandler(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "x/x")
+			_, err := w.Write([]byte(body))
+			if err != nil {
+				panic(err)
+			}
+		}), func(w http.ResponseWriter, r *http.Request) bool {
+		return true
+	})
+	s := httptest.NewServer(h)
+	defer s.Close()
+
+	req, err := http.NewRequest("GET", s.URL, nil)
+	if err != nil {
+		panic(err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	assertStatus(http.StatusOK, res.StatusCode, t)
+	assertHeader("Content-Encoding", "gzip", res, t)
+	assertGzippedBody([]byte(body), res, t)
+}

--- a/gzip/header.go
+++ b/gzip/header.go
@@ -1,0 +1,50 @@
+package gzip
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Kind of match to apply to the header check.
+type HeaderMatchType int
+
+const (
+	HmEquals HeaderMatchType = iota
+	HmStartsWith
+	HmEndsWith
+	HmContains
+)
+
+// Check if the specified header matches the test string, applying the header match type
+// specified.
+func HeaderMatch(hdr http.Header, nm string, matchType HeaderMatchType, test string) bool {
+	// First get the header value
+	val := hdr[http.CanonicalHeaderKey(nm)]
+	if len(val) == 0 {
+		return false
+	}
+	// Prepare the match test
+	test = strings.ToLower(test)
+	for _, v := range val {
+		v = strings.Trim(strings.ToLower(v), " \n\t")
+		switch matchType {
+		case HmEquals:
+			if v == test {
+				return true
+			}
+		case HmStartsWith:
+			if strings.HasPrefix(v, test) {
+				return true
+			}
+		case HmEndsWith:
+			if strings.HasSuffix(v, test) {
+				return true
+			}
+		case HmContains:
+			if strings.Contains(v, test) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/gzip/reswriter.go
+++ b/gzip/reswriter.go
@@ -1,0 +1,30 @@
+package gzip
+
+import (
+	"net/http"
+)
+
+// This interface can be implemented by an augmented ResponseWriter, so that
+// it doesn't hide other augmented writers in the chain.
+type WrapWriter interface {
+	http.ResponseWriter
+	WrappedWriter() http.ResponseWriter
+}
+
+// Helper function to retrieve a specific ResponseWriter.
+func GetResponseWriter(w http.ResponseWriter,
+	predicate func(http.ResponseWriter) bool) (http.ResponseWriter, bool) {
+
+	for {
+		// Check if this writer is the one we're looking for
+		if w != nil && predicate(w) {
+			return w, true
+		}
+		// If it is a WrapWriter, move back the chain of wrapped writers
+		ww, ok := w.(WrapWriter)
+		if !ok {
+			return nil, false
+		}
+		w = ww.WrappedWriter()
+	}
+}

--- a/gzip/utils_test.go
+++ b/gzip/utils_test.go
@@ -1,0 +1,68 @@
+package gzip
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func assertTrue(cond bool, msg string, t *testing.T) bool {
+	if !cond {
+		t.Error(msg)
+		return false
+	}
+	return true
+}
+
+func assertStatus(ex, ac int, t *testing.T) {
+	if ex != ac {
+		t.Errorf("expected status code to be %d, got %d", ex, ac)
+	}
+}
+
+func assertBody(ex []byte, res *http.Response, t *testing.T) {
+	buf, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		panic(err)
+	}
+	defer res.Body.Close()
+
+	if !bytes.Equal(ex, buf) {
+		t.Errorf("expected body to be '%s' (%d), got '%s' (%d)", ex, len(ex), buf, len(buf))
+	}
+}
+
+func assertGzippedBody(ex []byte, res *http.Response, t *testing.T) {
+	gr, err := gzip.NewReader(res.Body)
+	if err != nil {
+		panic(err)
+	}
+	defer res.Body.Close()
+
+	buf := bytes.NewBuffer(nil)
+	_, err = io.Copy(buf, gr)
+	if err != nil {
+		panic(err)
+	}
+	if !bytes.Equal(ex, buf.Bytes()) {
+		t.Errorf("expected unzipped body to be '%s' (%d), got '%s' (%d)", ex, len(ex), buf.Bytes(), buf.Len())
+	}
+}
+
+func assertHeader(hName, ex string, res *http.Response, t *testing.T) {
+	hVal, ok := res.Header[hName]
+	if (!ok || len(hVal) == 0) && len(ex) > 0 {
+		t.Errorf("expected header %s to be %s, was not set", hName, ex)
+	} else if len(hVal) > 0 && hVal[0] != ex {
+		t.Errorf("expected header %s to be %s, got %s", hName, ex, hVal)
+	}
+}
+
+func assertPanic(t *testing.T) {
+	if err := recover(); err == nil {
+		t.Error("expected a panic, got none")
+	}
+}


### PR DESCRIPTION
The homegrown gzip handler does not set the Content-Length correctly. Use the one from PuerkitoBio/ghost but copied and slightly edited to avoid the dependencies on everything else in ghost (e.g. redis). It turns us over to using `Transfer-Encoding: chunked`, instead.