### PR TITLE
add GOARCH to ensure we always get 64-bits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,9 @@ branches:
     - /^test_/
     - /^test-/
 
+env:
+  - GOARCH=amd64
+  - GOOS=linux
+  
 after_success:
   - ./travis_docker_push.sh


### PR DESCRIPTION
Probably unnecessary, but just in case. Also, set GOOS just for completion even though it will certainly never be different.