### PR TITLE
Check for a folder underneath google-cloud-sdk folder

### DIFF
--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -30,7 +30,7 @@ ls -l ${HOME}/google-cloud-sdk/
 echo "GCLOUD"
 
 function auth_gcloud() {
-  if [ ! -d ${HOME}/google-cloud-sdk ]; then
+  if [ ! -d ${HOME}/google-cloud-sdk/bin ]; then
     cd $HOME
     export CLOUDSDK_CORE_DISABLE_PROMPTS=1
     curl https://sdk.cloud.google.com | bash || die "unable to install gcloud"


### PR DESCRIPTION
Hey @jmhodges,

I would suggest to check for a folder underneath `$HOME/google-cloud-sdk` because this folder will be created by Travis CI under the hood when specifying it in the `cache.directories:` section of your .travis.yml file. Hence, `gcloud` won't be installed in this case.

Also, ensure to run at least 2 builds before seeing the cache in use: 1 build to populate the cache, 1 build to use it.

You can check the status of the cache in your build by searching the following phrases in the log and expanding them:

- `Setting up build cache`
- `store build cache`