### PR TITLE
use new Travis CI cache tech

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
     - /^test-/
 
 cache:
+  edge: true
   directories:
     - $HOME/google-cloud-sdk
 


### PR DESCRIPTION
Per recommendation from support because gcloud is never being cached.