### PR TITLE
include short git sha in docker tag

### DIFF
--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -54,9 +54,11 @@ docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS || die "unable to 
 
 REPO=jmhodges/howsmyssl
 
-# DEPLOY_IMAGE is usually something like jmhodges/howsmyssl:master-48 unless running on a
-# test_gcloud_deploy branch
-DEPLOY_IMAGE="$REPO:${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}"
+SHA=$(git rev-parse --short HEAD)
+
+# DEPLOY_IMAGE is usually something like jmhodges/howsmyssl:master-ffffff-48
+# unless running on a test_gcloud_deploy branch
+DEPLOY_IMAGE="$REPO:${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}-${SHA}"
 
 docker build -f Dockerfile -t $REPO .
 docker tag -f $REPO:$COMMIT $REPO:latest || die "unable to tag as latest"

--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -58,7 +58,7 @@ SHA=$(git rev-parse --short HEAD)
 
 # DEPLOY_IMAGE is usually something like jmhodges/howsmyssl:master-ffffff-48
 # unless running on a test_gcloud_deploy branch
-DEPLOY_IMAGE="$REPO:${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}-${SHA}"
+DEPLOY_IMAGE="$REPO:${TRAVIS_BUILD_NUMBER}-${TRAVIS_BRANCH}-${SHA}"
 
 docker build -f Dockerfile -t $REPO .
 docker tag -f $REPO:$COMMIT $REPO:latest || die "unable to tag as latest"


### PR DESCRIPTION
Includes the git short sha to make it easier to know where a tag came from and put the TRAVIS_BUILD_NUMBER first since it gives us an ordering that is pretty accurately simulates the order they were in.