### PR TITLE
avoid Travis's go get by taking over install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,8 @@ cache:
 env:
   - GOARCH=amd64 GOOS=linux
 
+install:
+  - go test -i ./... # Mostly to avoid Travis's default `go get`
+
 script:
   - go test -v ./... && ./travis_docker_push.sh


### PR DESCRIPTION
This ensures that we use our vendored dependencies.