### PR TITLE
count domains even when the domain map is empty

### DIFF
--- a/allow_test.go
+++ b/allow_test.go
@@ -121,7 +121,7 @@ func TestEmptyOriginAllowerAllowsAll(t *testing.T) {
 		t.Fatalf("unable to make request: %s", err)
 	}
 
-	tests := []string{"localhost", "example.com", "notreallyexample.com", "garbage"}
+	tests := []string{"localhost", "http://example.com", "https://notreallyexample.com", "garbage"}
 	for _, d := range tests {
 		r.Header.Set("Origin", d)
 		_, ok := oa.Allow(r)


### PR DESCRIPTION
Moving this len down let us count the domains even when we're not safelisting any domains at all.

Also, make the empty origin allower test reflect what we really wanted to test.