### PR TITLE
make origin config file specify domains to block

### DIFF
--- a/config/development_origins.json
+++ b/config/development_origins.json
@@ -1,5 +1,5 @@
 {
-  "allowed_origins": [
+  "blocked_origins": [
     "localhost",
     "example.com"
   ]


### PR DESCRIPTION
This changes the config file's contents from the domains to allow to the ones to block. This makes it possible to do our abuse prevention without maintaining a persistent rate limit count.

Fixes #103