### PR TITLE
fix deploy tooling that Google broke

### DIFF
--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -46,6 +46,15 @@ function auth_gcloud() {
   gcloud config set container/cluster sites
   gcloud config set compute/zone us-east1-c
   gcloud config set project personal-sites-1295
+
+  # As of sometime before Aug 12th, 2016, Google broke the ability for Google
+  # service accounts (not kube svc accounts?) to use kubectl outside the DC
+  # without the "legacy" setting use_client_certificate turned on. That's
+  # important to us because kubectl is how we do deploys. It's not clear that
+  # they have another solution on the way. The article that mentions this is
+  # https://cloud.google.com/container-engine/docs/iam-integration
+  gcloud config set container/use_client_certificate True
+
   gcloud container clusters get-credentials sites || die "unable to get credentials for GKE cluster"
 }
 


### PR DESCRIPTION
 With some help from another user in #google-containers in the Kubernetes slack,
 we found this "legacy" option that apparently does not have a new solution. See
 comment inside.