### PR TITLE
remove email flag from docker push

### DIFF
--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -68,7 +68,7 @@ if [[ "${DO_DEPLOY}" == "1" ]]; then
   AUTH_PID=$!
 fi
 
-docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS || die "unable to login"
+docker login -u $DOCKER_USER -p $DOCKER_PASS || die "unable to login"
 
 REPO=jmhodges/howsmyssl
 


### PR DESCRIPTION
It was quickly deprecated and then removed.