### PR TITLE
remove client certificate use in gcloud login

### DIFF
--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -47,14 +47,6 @@ function auth_gcloud() {
   gcloud config set compute/zone us-east1-c
   gcloud config set project personal-sites-1295
 
-  # As of sometime before Aug 12th, 2016, Google broke the ability for Google
-  # service accounts to use kubectl outside the DC without the "legacy" setting
-  # use_client_certificate turned on. That's important to us because kubectl is
-  # how we do deploys. It's not clear that they have another solution on the
-  # way. The article that mentions this is
-  # https://cloud.google.com/container-engine/docs/iam-integration
-  gcloud config set container/use_client_certificate True
-
   gcloud container clusters get-credentials sites || die "unable to get credentials for GKE cluster"
 }
 

--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -38,7 +38,9 @@ function auth_gcloud() {
     echo "Skipping gcloud download, using the cache of it"
   fi
   openssl aes-256-cbc -K $encrypted_46319ee087e0_key -iv $encrypted_46319ee087e0_iv -in howsmyssl-gcloud-credentials.json.enc -out ./howsmyssl-gcloud-credentials.json -d || die "unable to decrypt gcloud creds"
-  gcloud auth activate-service-account --key-file howsmyssl-gcloud-credentials.json || die "unable to authenticate gcloud service account"
+  gcloud auth activate-service-account --key-file howsmyssl-gcloud-credentials.json || die "unable to authenticate service account for gcloud"
+  gcloud beta auth application-default activate-service-account --key-file howsmyssl-gcloud-credentials.json || die "unable to authenticate gcloud service account"
+
   gcloud components update || die "unable to update all components"
   # This is for when we're on the first install of gcloud.
   gcloud components update kubectl || die "unable to install kubectl"


### PR DESCRIPTION
We now have a way to use kubectl patch without having to use the
client certificate. And we get roles working correctly, too.

Solved in kubernetes/kubernetes#30617