### PR TITLE
fix GKE deploy again

### DIFF
--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -38,8 +38,9 @@ function auth_gcloud() {
     echo "Skipping gcloud download, using the cache of it"
   fi
   openssl aes-256-cbc -K $encrypted_46319ee087e0_key -iv $encrypted_46319ee087e0_iv -in howsmyssl-gcloud-credentials.json.enc -out ./howsmyssl-gcloud-credentials.json -d || die "unable to decrypt gcloud creds"
+
+  # FIXME write comment
   gcloud auth activate-service-account --key-file howsmyssl-gcloud-credentials.json || die "unable to authenticate service account for gcloud"
-  gcloud beta auth application-default activate-service-account --key-file howsmyssl-gcloud-credentials.json || die "unable to authenticate gcloud service account"
 
   gcloud components update || die "unable to update all components"
   # This is for when we're on the first install of gcloud.
@@ -88,5 +89,7 @@ wait $AUTH_PID || die "unable to auth_gcloud"
 # all the escapes are to get access to ${DEPLOY_IMAGE} inside the string
 PATCH="[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/image\", \"value\": \"${DEPLOY_IMAGE}\"}]"
 
+# FIXME write second comment
+export GOOGLE_APPLICATION_CREDENTIALS="${PWD}/howsmyssl-gcloud-credentials.json"
 # quotes around PATCH are important since there are spaces in it.
 kubectl patch deployment --namespace=prod howsmyssl-deployment --type="json" -p "${PATCH}" || die "unable to deploy new image"


### PR DESCRIPTION
fix GKE deploy again

gcloud no longer has the `beta auth` commands, so we have to do the work
ourselves. The deal is this:

When running in CI or other systems on Google Cloud machines with a
restricted Google account associated (like how Travis CI is configured),
you have to use `gcloud auth activate-service-account` before calling
`gcloud container clusters get-credentials`, but then have to override
that authentication by setting GOOGLE_APPLICATION_CREDENTIALS before
calling `kubectl`.

See https://github.com/kubernetes/kubernetes/issues/30617