### PR TITLE
work harder to detect busted gcloud dirs

### DIFF
--- a/travis_docker_push.sh
+++ b/travis_docker_push.sh
@@ -28,7 +28,7 @@ fi
 
 function auth_gcloud() {
   export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-  if [ ! -d ${HOME}/google-cloud-sdk/bin ]; then
+  if [[ ! -d ${HOME}/google-cloud-sdk/bin || ! -f ${HOME}/google-cloud-sdk/bin/gcloud ]]; then
     # If there's no cache, TravisCI will put an empty directory there, which
     # gcloud's install script errors out on. So, delete it and do the download
     rm -rf ${HOME}/google-cloud-sdk


### PR DESCRIPTION
If a gcloud download and unpack failed midway, it might leave a directory with a
few files, but not all that we need. We could probably do with a manifest of
some kind, but this is patch that checks for the gcloud binary fixes the current
problem.