### PR TITLE
use defer when shutting down to avoid panics

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -200,18 +200,18 @@ func main() {
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
+		defer wg.Done()
 		err := httpsSrv.Shutdown(ctx)
 		if err != nil {
 			log.Printf("error shutting down HTTPS: %s", err)
 		}
-		wg.Done()
 	}()
 	go func() {
+		defer wg.Done()
 		err := httpSrv.Shutdown(ctx)
 		if err != nil {
 			log.Printf("error shutting down HTTP: %s", err)
 		}
-		wg.Done()
 	}()
 	wg.Wait()
 	cancel()


### PR DESCRIPTION
The `Done` methods might never be called if we panic.

An argument could be made that that is desirable so that kubernetes can tell us
when things are shutting down ungracefully, but I think that's unlikely to
happen and prefer all code using `WaitGroup`s to work the same so no one reading
this learns the wrong lessons