### PR TITLE
disallow Sweet32 ciphersuites out of order

### DIFF
--- a/client_info.go
+++ b/client_info.go
@@ -35,6 +35,7 @@ func ClientInfo(c *conn) *clientInfo {
 	if !st.HandshakeComplete {
 		panic("given a TLS conn that has not completed its handshake")
 	}
+	var sweet32Seen []string
 	for _, ci := range st.ClientCipherSuites {
 		s, found := allCipherSuites[ci]
 		if found {
@@ -66,6 +67,14 @@ func ClientInfo(c *conn) *clientInfo {
 				s = w
 				d.InsecureCipherSuites[s] = append(d.InsecureCipherSuites[s], weirdNSSReason)
 			}
+		}
+		if sweet32CipherSuites[s] {
+			sweet32Seen = append(sweet32Seen, s)
+		} else if len(sweet32Seen) != 0 {
+			for _, seen := range sweet32Seen {
+				d.InsecureCipherSuites[seen] = append(d.InsecureCipherSuites[seen], sweet32Reason)
+			}
+			sweet32Seen = []string{}
 		}
 		d.GivenCipherSuites = append(d.GivenCipherSuites, s)
 	}

--- a/insecure_suites.go
+++ b/insecure_suites.go
@@ -6,6 +6,7 @@ var (
 	nullAuthReason = "is open to man-in-the-middle attacks because it does not authenticate the server"
 	weirdNSSReason = "was meant to die with SSL 3.0 and is of unknown safety"
 	rc4Reason      = "uses RC4 which has insecure biases in its output"
+	sweet32Reason  = "uses 3DES which is vulnerable to the Sweet32 attack but was not configured as a fallback in the ciphersuite order"
 )
 
 // Cipher suites with less than 128-bit encryption.
@@ -159,6 +160,29 @@ var rc4CipherSuites = map[string]bool{
 	"TLS_RSA_EXPORT1024_WITH_RC4_56_SHA":     true,
 	"TLS_DHE_DSS_EXPORT1024_WITH_RC4_56_SHA": true,
 	"TLS_DHE_DSS_WITH_RC4_128_SHA":           true,
+}
+
+var sweet32CipherSuites = map[string]bool{
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA":         true,
+	"TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA":      true,
+	"TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA":      true,
+	"TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA":     true,
+	"TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA":     true,
+	"TLS_DH_anon_WITH_3DES_EDE_CBC_SHA":     true,
+	"TLS_KRB5_WITH_3DES_EDE_CBC_SHA":        true,
+	"TLS_KRB5_WITH_3DES_EDE_CBC_MD5":        true,
+	"TLS_PSK_WITH_3DES_EDE_CBC_SHA":         true,
+	"TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA":     true,
+	"TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA":     true,
+	"TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA":  true,
+	"TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA": true,
+	"TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA":    true,
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":   true,
+	"TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA":   true,
+	"TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA":     true,
+	"TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA": true,
+	"TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA": true,
+	"TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA":   true,
 }
 
 // Obsolete cipher suites in NSS that were meant to die with SSL 3.0 but


### PR DESCRIPTION
Sweet32 ciphersuites should only be allowed as fallbacks now.