### PR TITLE
some linter fixes

### DIFF
--- a/allow.go
+++ b/allow.go
@@ -251,7 +251,7 @@ func loadGoogleServiceAccount(fp string) *googleConfig {
 type googleConfig struct {
 	ProjectID string `json:"project_id"`
 
-	conf *jwt.Config `json:"-"`
+	conf *jwt.Config
 }
 
 var _ logClient = nullLogClient{}

--- a/client_info.go
+++ b/client_info.go
@@ -7,12 +7,12 @@ import (
 	tls "github.com/jmhodges/howsmyssl/tls18"
 )
 
-type Rating string
+type rating string
 
 const (
-	okay       Rating = "Probably Okay"
-	improvable Rating = "Improvable"
-	bad        Rating = "Bad"
+	okay       rating = "Probably Okay"
+	improvable rating = "Improvable"
+	bad        rating = "Bad"
 )
 
 type clientInfo struct {
@@ -25,10 +25,10 @@ type clientInfo struct {
 	AbleToDetectNMinusOneSplitting bool                `json:"able_to_detect_n_minus_one_splitting"` // neutral
 	InsecureCipherSuites           map[string][]string `json:"insecure_cipher_suites"`
 	TLSVersion                     string              `json:"tls_version"`
-	Rating                         Rating              `json:"rating"`
+	Rating                         rating              `json:"rating"`
 }
 
-func ClientInfo(c *conn) *clientInfo {
+func pullClientInfo(c *conn) *clientInfo {
 	d := &clientInfo{InsecureCipherSuites: make(map[string][]string)}
 
 	st := c.ConnectionState()

--- a/conn.go
+++ b/conn.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	_                net.Listener = &listener{}
-	_                net.Conn     = &conn{}
-	tlsConnConvError              = errors.New("Unable to convert net.Conn to tls.Conn")
+	_              net.Listener = &listener{}
+	_              net.Conn     = &conn{}
+	errTLSConnConv              = errors.New("Unable to convert net.Conn to tls.Conn")
 )
 
 type listener struct {
@@ -67,7 +67,7 @@ func (l *listener) Accept() (net.Conn, error) {
 	tlsConn, ok := c.(*tls.Conn)
 	if !ok {
 		c.Close()
-		return nil, tlsConnConvError
+		return nil, errTLSConnConv
 	}
 	return &conn{
 		Conn:           tlsConn,

--- a/stat_writer.go
+++ b/stat_writer.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	_                 http.Hijacker = &statWriter{}
-	notAHijackerError               = errors.New("statWriter: given ResponseWriter was not a Hijacker")
+	_               http.Hijacker = &statWriter{}
+	errNotAHijacker               = errors.New("statWriter: given ResponseWriter was not a Hijacker")
 )
 
 type statusStats struct {
@@ -21,7 +21,7 @@ type statusStats struct {
 	status5xx *expvar.Int
 }
 
-func NewStatusStats(outer *expvar.Map) *statusStats {
+func newStatusStats(outer *expvar.Map) *statusStats {
 	m := new(expvar.Map).Init()
 	outer.Set("statuses", m)
 	status1xx := &expvar.Int{}
@@ -82,7 +82,7 @@ func (sw *statWriter) Header() http.Header {
 func (sw *statWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hj, ok := sw.w.(http.Hijacker)
 	if !ok {
-		return nil, nil, notAHijackerError
+		return nil, nil, errNotAHijacker
 	}
 	return hj.Hijack()
 }

--- a/tls_test.go
+++ b/tls_test.go
@@ -31,7 +31,7 @@ func TestBEASTVuln(t *testing.T) {
 		if !st.NMinusOneRecordSplittingDetected {
 			t.Errorf("TLS 1.0, CBC suite, Conn: NMinusOneRecordSplittingDetected was false")
 		}
-		ci := ClientInfo(c)
+		ci := pullClientInfo(c)
 		if ci.BEASTVuln {
 			t.Errorf("TLS 1.0, CBC suite, ClientInfo: BEASTVuln should be false because Go mitigates the BEAST attack even on TLS 1.0")
 		}
@@ -52,7 +52,7 @@ func TestBEASTVuln(t *testing.T) {
 		if st.AbleToDetectNMinusOneSplitting {
 			t.Errorf("TLS 1.0, no CBC suites, Conn: AbleToDetectNMinusOneSplitting was true")
 		}
-		ci := ClientInfo(c)
+		ci := pullClientInfo(c)
 		if ci.BEASTVuln {
 			t.Errorf("TLS 1.0, no CBC suites, ClientInfo: BEASTVuln should be false because Go mitigates the BEAST attack even on TLS 1.0")
 		}
@@ -71,7 +71,7 @@ func TestBEASTVuln(t *testing.T) {
 		if st.AbleToDetectNMinusOneSplitting {
 			t.Errorf("TLS 1.2+, no CBC suites, Conn: AbleToDetectNMinusOneSplitting was true")
 		}
-		ci := ClientInfo(c)
+		ci := pullClientInfo(c)
 		if ci.BEASTVuln {
 			t.Errorf("TLS 1.2+, no CBC suites, ClientInfo: BEASTVuln should be false because Go mitigates the BEAST attack even on TLS 1.0")
 		}
@@ -87,7 +87,7 @@ func TestBEASTVuln(t *testing.T) {
 func TestGoDefaultIsOkay(t *testing.T) {
 	clientConf := &tls.Config{}
 	c := connect(t, clientConf)
-	ci := ClientInfo(c)
+	ci := pullClientInfo(c)
 	t.Logf("%#v", ci)
 
 	if ci.Rating != okay {
@@ -129,7 +129,7 @@ func TestSweet32(t *testing.T) {
 			CipherSuites: st.suites,
 		}
 		c := connect(t, clientConf)
-		ci := ClientInfo(c)
+		ci := pullClientInfo(c)
 		t.Logf("#%d, %#v", i, ci)
 
 		if ci.Rating != bad {


### PR DESCRIPTION
Mostly renames of unexporting funcs and structs which isn't really a concern in a binary, but makes various linters get quieter. Also, an unnecessary json tag is removed.