### PR TITLE
Add minVersion option to change minimal ssl/tls required version.

### DIFF
--- a/tls_test.go
+++ b/tls_test.go
@@ -148,7 +148,7 @@ var serverConf *tls.Config
 var rootCA *x509.Certificate
 
 func init() {
-	serverConf = makeTLSConfig("./config/development_cert.pem", "./config/development_key.pem")
+	serverConf = makeTLSConfig("./config/development_cert.pem", "./config/development_key.pem", tls.VersionSSL30)
 	certBytes, err := ioutil.ReadFile("./config/development_ca_cert.pem")
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Hi,

I needed to test my http client with a tls 1.2 only server configuration.
I wrote a patch to specify I want only 1.2. Maybe this could be helpful to other people so here is the PR.

Thanks for your project anyway it's very helpful.