### PR TITLE
allow meta cipher suites to come after Sweet32 suites

### DIFF
--- a/all_suites.go
+++ b/all_suites.go
@@ -382,3 +382,28 @@ var allCipherSuites = map[uint16]string{
 	0x0060: "TLS_RSA_EXPORT1024_WITH_RC4_56_MD5",
 	0x0061: "TLS_RSA_EXPORT1024_WITH_RC2_CBC_56_MD5",
 }
+
+// metaCipherSuites are cipher suite settings that aren't actual cipher suites,
+// but are used to communicate info about the client or server.
+var metaCipherSuites = map[uint16]bool{
+	// GREASE cipher suites
+	0x0A0A: true,
+	0x1A1A: true,
+	0x2A2A: true,
+	0x3A3A: true,
+	0x4A4A: true,
+	0x5A5A: true,
+	0x6A6A: true,
+	0x7A7A: true,
+	0x8A8A: true,
+	0x9A9A: true,
+	0xAAAA: true,
+	0xBABA: true,
+	0xCACA: true,
+	0xDADA: true,
+	0xEAEA: true,
+	0xFAFA: true,
+
+	// TLS_EMPTY_RENEGOTIATION_INFO_SCSV
+	0x00FF: true,
+}

--- a/client_info.go
+++ b/client_info.go
@@ -58,6 +58,14 @@ func pullClientInfo(c *conn) *clientInfo {
 			if rc4CipherSuites[s] {
 				d.InsecureCipherSuites[s] = append(d.InsecureCipherSuites[s], rc4Reason)
 			}
+			if sweet32CipherSuites[s] {
+				sweet32Seen = append(sweet32Seen, s)
+			} else if len(sweet32Seen) != 0 && !metaCipherSuites[ci] {
+				for _, seen := range sweet32Seen {
+					d.InsecureCipherSuites[seen] = append(d.InsecureCipherSuites[seen], sweet32Reason)
+				}
+				sweet32Seen = []string{}
+			}
 		} else {
 			w, found := weirdNSSSuites[ci]
 			if !found {
@@ -67,14 +75,6 @@ func pullClientInfo(c *conn) *clientInfo {
 				s = w
 				d.InsecureCipherSuites[s] = append(d.InsecureCipherSuites[s], weirdNSSReason)
 			}
-		}
-		if sweet32CipherSuites[s] {
-			sweet32Seen = append(sweet32Seen, s)
-		} else if len(sweet32Seen) != 0 {
-			for _, seen := range sweet32Seen {
-				d.InsecureCipherSuites[seen] = append(d.InsecureCipherSuites[seen], sweet32Reason)
-			}
-			sweet32Seen = []string{}
 		}
 		d.GivenCipherSuites = append(d.GivenCipherSuites, s)
 	}

--- a/tls18/handshake_client.go
+++ b/tls18/handshake_client.go
@@ -79,6 +79,14 @@ func (c *Conn) clientHandshake() error {
 NextCipherSuite:
 	for _, suiteId := range possibleCipherSuites {
 		for _, suite := range cipherSuites {
+			// Explicitly whitelisting some meta cipher suites as okay to be
+			// used in TestSweet32 in howsmyssl's client config
+
+			if suiteId == 0x00FF || suiteId == 0x0A0A {
+				hello.cipherSuites = append(hello.cipherSuites, suiteId)
+				continue NextCipherSuite
+			}
+
 			if suite.id != suiteId {
 				continue
 			}


### PR DESCRIPTION
Things like renegotiation and GREASE should be allowed to be configured after
the Sweet32 cipher suites.