### PR TITLE
patch tls110 with vuln detection and use it

### DIFF
--- a/client_info.go
+++ b/client_info.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	tls "github.com/jmhodges/howsmyssl/tls18"
+	tls "github.com/jmhodges/howsmyssl/tls110"
 )
 
 type rating string

--- a/conn.go
+++ b/conn.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"sync/atomic"
 
-	tls "github.com/jmhodges/howsmyssl/tls18"
+	tls "github.com/jmhodges/howsmyssl/tls110"
 )
 
 var (

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -26,7 +26,7 @@ import (
 
 	"cloud.google.com/go/logging"
 	"github.com/jmhodges/howsmyssl/gzip"
-	tls "github.com/jmhodges/howsmyssl/tls18"
+	tls "github.com/jmhodges/howsmyssl/tls110"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
 )

--- a/reloader.go
+++ b/reloader.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	tls "github.com/jmhodges/howsmyssl/tls18"
+	tls "github.com/jmhodges/howsmyssl/tls110"
 )
 
 func newKeypairReloader(certPath, keyPath string) (*keypairReloader, error) {

--- a/tls110/common.go
+++ b/tls110/common.go
@@ -170,6 +170,13 @@ type ConnectionState struct {
 	// change in future versions of Go once the TLS master-secret fix has
 	// been standardized and implemented.
 	TLSUnique []byte
+
+	// Added for howsmyssl's use
+	ClientCipherSuites               []uint16
+	CompressionMethods               []uint8
+	NMinusOneRecordSplittingDetected bool
+	AbleToDetectNMinusOneSplitting   bool
+	SessionTicketsSupported          bool
 }
 
 // ClientAuthType declares the policy the server will follow for

--- a/tls110/conn.go
+++ b/tls110/conn.go
@@ -104,6 +104,12 @@ type Conn struct {
 	activeCall int32
 
 	tmp [16]byte
+
+	// Added for howsmyssl's use
+	clientHello                      *clientHelloMsg
+	ableToDetectNMinusOneSplitting   bool
+	readOneAppDataRecord             bool
+	nMinusOneRecordSplittingDetected bool
 }
 
 // Access to net.Conn methods.
@@ -665,6 +671,19 @@ Again:
 	if typ != recordTypeAlert && len(data) > 0 {
 		// this is a valid non-alert message: reset the count of alerts
 		c.warnCount = 0
+	}
+
+	// This detects BEAST mitigation when the first app data record is
+	// of length 1 or 0. Length 1 mitigation is common in web browsers, while
+	// length 0 is common in OpenSSL tools. Since the requests to
+	// /a/check are typically very small, this won't detect the Java
+	// style BEAST mitigation where the 1 byte record is sent after
+	// the first application record but only if its large enough.
+	//
+	// TODO(jmhodges): check that 1 or 0 byte records are sent between others
+	if !c.readOneAppDataRecord && c.ableToDetectNMinusOneSplitting && want == recordTypeApplicationData {
+		c.readOneAppDataRecord = true
+		c.nMinusOneRecordSplittingDetected = len(data) == 1 || len(data) == 0
 	}
 
 	switch typ {
@@ -1376,6 +1395,13 @@ func (c *Conn) ConnectionState() ConnectionState {
 				state.TLSUnique = c.serverFinished[:]
 			}
 		}
+		state.ClientCipherSuites = make([]uint16, len(c.clientHello.cipherSuites))
+		copy(state.ClientCipherSuites, c.clientHello.cipherSuites)
+		state.CompressionMethods = make([]uint8, len(c.clientHello.compressionMethods))
+		copy(state.CompressionMethods, c.clientHello.compressionMethods)
+		state.AbleToDetectNMinusOneSplitting = c.ableToDetectNMinusOneSplitting
+		state.NMinusOneRecordSplittingDetected = c.nMinusOneRecordSplittingDetected
+		state.SessionTicketsSupported = c.clientHello.ticketSupported
 	}
 
 	return state

--- a/tls110/handshake_client.go
+++ b/tls110/handshake_client.go
@@ -66,6 +66,14 @@ func makeClientHello(config *Config) (*clientHelloMsg, error) {
 NextCipherSuite:
 	for _, suiteId := range possibleCipherSuites {
 		for _, suite := range cipherSuites {
+			// Explicitly whitelisting some meta cipher suites as okay to be
+			// used in TestSweet32 in howsmyssl's client config
+
+			if suiteId == 0x00FF || suiteId == 0x0A0A {
+				hello.cipherSuites = append(hello.cipherSuites, suiteId)
+				continue NextCipherSuite
+			}
+
 			if suite.id != suiteId {
 				continue
 			}

--- a/tls_test.go
+++ b/tls_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	tls "github.com/jmhodges/howsmyssl/tls18"
+	tls "github.com/jmhodges/howsmyssl/tls110"
 )
 
 func TestBEASTVuln(t *testing.T) {
@@ -111,8 +111,18 @@ func TestSweet32(t *testing.T) {
 		suites   []uint16
 		expected map[string][]string
 	}
-	// These are explicitly whitelisted as okay in tls18/handshake_client.go, so
-	// we have to use just them.
+
+	// Since the Sweet32 vulnerable ciphersuites are still used by many servers,
+	// Sweet32 mitigation involves moving those ciphersuites to the end of the
+	// ciphersuite list the client announces it can support. However, meta
+	// ciphersuites like the GREASE or renegotiation ciphersuites are also
+	// attached to the end. So, howsmyssl says a client is vulnerable to Sweet32
+	// if the Sweet32 vulnerable ciphersuites are last or would be last except
+	// for some known meta ciphersuites like GREASE, etc. In order to support
+	// testing this behavior, we had to hardcode into tls110/handshake_client.go
+	// the meta ciphersuites we support here to pass them to the server without
+	// dropping them like the client usually would.  We don't use the tls110
+	// client code anywhere but in these tests, so this isn't so bad.
 	greaseCS := uint16(0x0A0A)
 	renegCS := uint16(0x00FF)
 	tests := []sweetTest{


### PR DESCRIPTION
This patches the tls110 package to include the vulnerability detection that we
have in tls18 already and uses tls110 instead of tls18 in howsmyssl.