### PR TITLE
support TLS 1.3 supported_versions extension

### DIFF
--- a/tls110/common.go
+++ b/tls110/common.go
@@ -84,6 +84,9 @@ const (
 	extensionSessionTicket       uint16 = 35
 	extensionNextProtoNeg        uint16 = 13172 // not IANA assigned
 	extensionRenegotiationInfo   uint16 = 0xff01
+
+	// added for howsmyssl's early TLS 1.3 support
+	extensionSupportedVersions uint16 = 43
 )
 
 // TLS signaling cipher suite values
@@ -177,6 +180,7 @@ type ConnectionState struct {
 	NMinusOneRecordSplittingDetected bool
 	AbleToDetectNMinusOneSplitting   bool
 	SessionTicketsSupported          bool
+	SupportedVersions                []uint16
 }
 
 // ClientAuthType declares the policy the server will follow for

--- a/tls110/conn.go
+++ b/tls110/conn.go
@@ -1402,6 +1402,7 @@ func (c *Conn) ConnectionState() ConnectionState {
 		state.AbleToDetectNMinusOneSplitting = c.ableToDetectNMinusOneSplitting
 		state.NMinusOneRecordSplittingDetected = c.nMinusOneRecordSplittingDetected
 		state.SessionTicketsSupported = c.clientHello.ticketSupported
+		state.SupportedVersions = c.clientHello.supportedVersions
 	}
 
 	return state


### PR DESCRIPTION
Recent versions of the TLS 1.3 draft use a TLS extension called
supported_versions to announce the versions supported by the client. And
TLS 1.3 clients that support different drafts of the TLS 1.3 specs send
down different versions with the spec draft number bitmasked in.

This patch adds support for all of that behavior.

Fixes #201.