### PR TITLE
predict a few more TLS 1.3 drafts will happen

### DIFF
--- a/client_info.go
+++ b/client_info.go
@@ -39,6 +39,11 @@ const (
 	versionTLS13Draft26        = 0x7f00 | 26
 	versionTLS13Draft27        = 0x7f00 | 27
 	versionTLS13Draft28        = 0x7f00 | 28
+	versionTLS13Draft29        = 0x7f00 | 29
+	versionTLS13Draft30        = 0x7f00 | 30
+	versionTLS13Draft31        = 0x7f00 | 31
+	versionTLS13Draft32        = 0x7f00 | 32
+	versionTLS13Draft33        = 0x7f00 | 33
 )
 
 var actualSupportedVersions = map[uint16]string{
@@ -56,6 +61,11 @@ var actualSupportedVersions = map[uint16]string{
 	versionTLS13Draft26: "TLS 1.3",
 	versionTLS13Draft27: "TLS 1.3",
 	versionTLS13Draft28: "TLS 1.3",
+	versionTLS13Draft29: "TLS 1.3",
+	versionTLS13Draft30: "TLS 1.3",
+	versionTLS13Draft31: "TLS 1.3",
+	versionTLS13Draft32: "TLS 1.3",
+	versionTLS13Draft33: "TLS 1.3",
 }
 
 func pullClientInfo(c *conn) *clientInfo {


### PR DESCRIPTION
This adds more TLS 1.3 versions that could show up in its
supported_versions extensions. Might still need more, but we're at draft
26 and we're doing about 1.5 versions a month right now. That rate of
versioning might accelerate as it gets closer to done