### PR TITLE
use BadRequest instead of TooManyRequests

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -328,7 +328,7 @@ func disallowedRenderJSON(r *http.Request, data *clientInfo) ([]byte, int, strin
 		return body, http.StatusOK, "application/javascript", nil
 
 	}
-	return disallowedOriginBody, http.StatusTooManyRequests, "application/json", nil
+	return disallowedOriginBody, http.StatusBadRequest, "application/json", nil
 }
 
 func allowedRenderJSON(r *http.Request, data *clientInfo) ([]byte, int, string, error) {

--- a/index_test.go
+++ b/index_test.go
@@ -271,7 +271,7 @@ func TestJSONAPI(t *testing.T) {
 		{
 			path:        "/a/check",
 			origin:      "https://blocked.com",
-			status:      http.StatusTooManyRequests,
+			status:      http.StatusBadRequest,
 			contentType: "application/json",
 			body:        string(disallowedOriginBody),
 		},


### PR DESCRIPTION
TooManyRequests implies to people that there will be strict API rate limits
instead of just needing to purchase a subscription which only has overage
charges.