### PR TITLE
downcase urls for correct logging

### DIFF
--- a/allow.go
+++ b/allow.go
@@ -127,6 +127,7 @@ func (oa *originAllower) Allow(r *http.Request) (string, bool) {
 // checkDomain checks if the detected domain from the request headers and
 // whether domain is allowed to make requests against howsmyssl's API.
 func (oa *originAllower) checkDomain(d string) (string, string, bool) {
+	d = strings.ToLower(d)
 	etldplus1, fullDomain, err := effectiveDomain(d)
 
 	if err != nil {

--- a/allow_test.go
+++ b/allow_test.go
@@ -65,6 +65,8 @@ func TestOriginAllowerWithLocalhost(t *testing.T) {
 
 		{"https://example.com:3336/", "", "example.com", false},
 		{"", "http://example.com:4444/asdf", "example.com", false},
+		{"https://eXampLe.com", "", "example.com", false},
+		{"", "https://eXaMPle.com/foobar", "example.com", false},
 	}
 
 	r, err := http.NewRequest("GET", "/whatever", nil)


### PR DESCRIPTION
Some urls (I believe, in Referrers) were not being downcased by browsers before
being sent to howsmyssl.com. So, adjust that.