### PR TITLE
add Github Action refresh our dev certs

### DIFF
--- a/.github/workflows/update_dev_certs.yml
+++ b/.github/workflows/update_dev_certs.yml
@@ -1,0 +1,29 @@
+name: Update dev environment certificates
+on:
+  schedule:
+    # Do this every 4 months. 3:01 AM on every 7th of the month was picked
+    # arbitrarily (c.f. fine-structure constant)
+    - cron: '1 3 7 */4 *'
+  push:
+    branches:
+      - force_update_dev_certs
+jobs:
+  make_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          ref: master
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.1
+      - run: go build -o ./gendevcerts/gendevcerts ./gendevcerts
+      - run: ./gendevcerts/gendevcerts -d ./config
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v1.3.1
+        env:
+          PULL_REQUEST_TITLE: four month update of dev environment certificates
+          COMMIT_MESSAGE: four month update of dev env certificates
+          PULL_REQUEST_BRANCH: auto_update_dev_certs
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Our dev certs keep needing refreshing, but I'd rather not do it by hand. And I'd
rather not have to generate RSA keys on every test run. So, let's automate this.