### PR TITLE
Revert "delete Travis CI config (#268)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+go:
+- 1.13.3
+sudo: required
+services:
+- docker
+branches:
+  only:
+  - master
+  - /^test_/
+  - /^test-/
+cache:
+  edge: true
+  directories:
+  - $HOME/google-cloud-sdk
+env:
+- GOARCH=amd64 GOOS=linux GO111MODULE=on
+install:
+- go test -mod=vendor -i -race . ./tls110 ./gzip
+script:
+- go test -mod=vendor -v -race . ./tls110 ./gzip && ./travis_docker_push.sh


### PR DESCRIPTION
This reverts commit dab6fa60824119b2124f0b27b97cd8f4d39b62c1.

Got too hasty with #268. We still need Travis for the deploy code.