### PR TITLE
use go-version-file with our version file

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,14 +17,10 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
 
-    - name: Read Go version
-      run: echo "##[set-output name=go_version;]$(cat .github/versions/go)"
-      id: go_version
-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version:  ${{ steps.go_version.outputs.go_version }}
+        go-version-file: .github/versions/go
       id: go
 
     - name: Install test dependencies

--- a/.github/workflows/update_dev_certs.yml
+++ b/.github/workflows/update_dev_certs.yml
@@ -14,13 +14,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: master
-      - name: Read Go version
-        run: echo "##[set-output name=go_version;]$(cat .github/versions/go)"
-        id: go_version
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version:  ${{ steps.go_version.outputs.go_version }}
+          go-version-file: .github/versions/go
       - run: go build -o ./gendevcerts/gendevcerts ./gendevcerts
       - run: ./gendevcerts/gendevcerts -d ./config
       - name: Get current date


### PR DESCRIPTION
It turns out the actions/setup-go module does support using plain
version files for their go-version-file!

Since the Go version in `go.mod` is too imprecise (and isn't updated by
dependabot, anyway) for our purposes, let's use the plain version file
we've had around for a while.
