### PR TITLE
remove install step from build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,10 +22,6 @@ jobs:
           go-version-file: .github/versions/go
         id: go
 
-      - name: Install test dependencies
-        run: |
-          go test -mod=vendor -i -race . ./tls110 ./gzip
-
       - name: Run tests
         run: |
-          go test -mod=vendor -race . ./tls110 ./gzip
+          go test -mod=vendor -race ./...


### PR DESCRIPTION
Running `go test ./...` no longer runs all the vendored library tests,
and whatever caching the install step was doing is now handled by Go's
module system internally. So, we can just do the test run.
