### PR TITLE
dedupe deploy by making new workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,0 +1,18 @@
+name: Build and deploy
+on:
+  push:
+    branches:
+      - master
+      - "test_deploy_*"
+      - "test-deploy-*"
+      - "test_deploy-*"
+      - "test-deploy_*"
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Go
+        uses: jmhodges/howsmyssl/.github/workflows/go.yml
+      - name: Deploy
+        uses: jmhodges/howsmyssl/.github/workflows/deploy.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,17 +3,7 @@
 
 name: Deploy
 on:
-  workflow_run:
-    workflows:
-      - Go
-    types:
-      - completed
-    branches:
-      - master
-      - "test_deploy_*"
-      - "test-deploy-*"
-      - "test_deploy-*"
-      - "test-deploy_*"
+  workflow_call:
 
 jobs:
   deploy:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,12 +2,13 @@ name: Go
 on:
   push:
     branches:
-      - master
       - "test_*"
       - "test-*"
   pull_request:
     branches:
       - master
+  workflow_call:
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
The deploy.yml workflow was being called twice on every merge to master.
Solve this without deploying on pull requests with a new workflow that
calls go.yml and deploy.yml on pushes to master and the test deploy
branches.
