### PR TITLE
de-dupe Go calls on test- branches

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -3,15 +3,18 @@ on:
   push:
     branches:
       - master
-      - "test_deploy_*"
-      - "test-deploy-*"
-      - "test_deploy-*"
-      - "test-deploy_*"
+      - "test_*"
+      - "test-*"
+  pull_request:
+    branches:
+      - master
+
 jobs:
   build:
     name: Build
     uses: ./.github/workflows/go.yml
   deploy:
     needs: build
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/test_docker_') || startsWith(github.ref, 'refs/heads/test-docker-')
     name: Deploy
     uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,12 +1,5 @@
 name: Go
 on:
-  push:
-    branches:
-      - "test_*"
-      - "test-*"
-  pull_request:
-    branches:
-      - master
   workflow_call:
 
 jobs:


### PR DESCRIPTION
Previous config would have the go.yml workflow running twice on
test-deploy-* branches because go.yml looked to be run on `test-*`
branches and build_and_deploy.yml looked to be run on `test-docker-*`
branches.

Give up on using the built-in pattern matching and apply our own with
`if:`.
