### PR TITLE
continuously deploy with GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,12 @@ name: Deploy
 on:
   workflow_call:
 
+concurrency: production
+
+permissions:
+  id-token: write # For Google OIDC workload identity things
+  contents: read
+
 jobs:
   deploy:
     name: Deploy
@@ -13,5 +19,36 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 
-      - name: Do nothing
-        run: echo "Doing nothing"
+      - id: auth
+        uses: google-github-actions/auth@v1.1.0
+        with:
+          workload_identity_provider: "projects/852340051888/locations/global/workloadIdentityPools/github-deploy/providers/github-deploy"
+          service_account: "howsmyssl-deploy@personal-sites-1295.iam.gserviceaccount.com"
+          create_credentials_file: true
+
+      - id: get-gke-credentials
+        uses: google-github-actions/get-gke-credentials@v1.0.1
+        with:
+          cluster_name: dg
+          location: us-central1-c
+
+      - id: update-label
+        run: kubectl -n prod label --overwrite deploy howsmyssl lookatme="${GITHUB_SHA}-${GITHUB_RUN_NUMBER}"
+
+      - id: gcloud-config-docker
+        run: gcloud auth configure-docker -q us-central1-docker.pkg.dev
+
+      - id: docker-build
+        run: docker build -t us-central1-docker.pkg.dev/personal-sites-1295/deploys/howsmyssl:v1-${GITHUB_SHA} .
+
+      - id: docker-push
+        run: docker push us-central1-docker.pkg.dev/personal-sites-1295/deploys/howsmyssl:v1-${GITHUB_SHA}
+
+      - id: sha256-of-docker-image
+        run: echo "IMAGE_SHA256=$(docker inspect --format='{{index .RepoDigests}}' us-central1-docker.pkg.dev/personal-sites-1295/deploys/howsmyssl:v1-${GITHUB_SHA})" >> "$GITHUB_OUTPUT"
+
+      - id: check-output
+        run: echo "found as ${{steps.sha256-of-docker-image.outputs.IMAGE_SHA256}}"
+
+      - id: get-deploys
+        run: kubectl -n prod set image deployment/howsmyssl howsmyssl=us-central1-docker.pkg.dev/personal-sites-1295/deploys/howsmyssl:v1-${GITHUB_SHA}@sha256:${{ steps.sha256-of-docker-image.outputs.IMAGE_SHA256 }}


### PR DESCRIPTION
Use GitHub Actions to deploy to Google Kubernetes Engine on merges to
master.

Uses OIDC to authenticate to GKE. Set up is done in private code.
