### PR TITLE
remove port stripping hack from our handlers

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -597,12 +597,6 @@ type protoHandler struct {
 
 func (h protoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.Header.Set(xForwardedProto, h.proto)
-	// TODO(jmhodges): gross hack in order to get ServeMux to match ports
-	// See https://golang.org/issue/10463
-	host, _, err := net.SplitHostPort(r.Host)
-	if err == nil {
-		r.Host = host
-	}
 	h.inner.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
In response to #25, we added this hack to strip the port of the Host
header before passing it to our virtual host redirecting ServeMux. I
also filed https://github.com/golang/go/issues/10463 and that was fixed
in 2017 and released soon after.

So, since we're on a modern version of Go, this code is redundant and
can be removed.
