### PR TITLE
use modern time.Since

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -78,10 +78,10 @@ func main() {
 	expvar.NewInt("start_time_epoch_secs").Set(t.Unix())
 	expvar.NewString("start_time_timestamp").Set(t.Format(time.RFC3339))
 	expvar.Publish("uptime_secs", expvar.Func(func() interface{} {
-		return int64(time.Now().Sub(t) / time.Second)
+		return int64(time.Since(t) / time.Second)
 	}))
 	expvar.Publish("uptime_dur", expvar.Func(func() interface{} {
-		return time.Now().Sub(t).String()
+		return time.Since(t).String()
 	}))
 
 	routeHost, redirectHost := calculateDomains(*rawVHost, *httpsAddr)


### PR DESCRIPTION
The pattern time.Now().Sub has been replaced with time.Since for a long
while now.
