### PR TITLE
run gofmt -w -s

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -147,25 +147,25 @@ type vhostTest struct {
 
 func TestVHostCalculation(t *testing.T) {
 	tests := []vhostTest{
-		vhostTest{
+		{
 			rawVHost:             "www.howsmyssl.com",
 			httpsAddr:            "0:10443",
 			expectedRouteHost:    "www.howsmyssl.com",
 			expectedRedirectHost: "www.howsmyssl.com",
 		},
-		vhostTest{
+		{
 			rawVHost:             "localhost:10443",
 			httpsAddr:            "localhost:10443",
 			expectedRouteHost:    "localhost",
 			expectedRedirectHost: "localhost:10443",
 		},
-		vhostTest{
+		{
 			rawVHost:             "example.com:10443",
 			httpsAddr:            "localhost:10443",
 			expectedRouteHost:    "example.com",
 			expectedRedirectHost: "example.com:10443",
 		},
-		vhostTest{
+		{
 			rawVHost:             "example.com:443",
 			httpsAddr:            "0:443",
 			expectedRouteHost:    "example.com",

--- a/tls_test.go
+++ b/tls_test.go
@@ -131,15 +131,15 @@ func TestSweet32(t *testing.T) {
 			bad,
 			[]uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
 			map[string][]string{
-				"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA": []string{sweet32Reason},
-				"TLS_RSA_WITH_3DES_EDE_CBC_SHA":       []string{sweet32Reason},
+				"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA": {sweet32Reason},
+				"TLS_RSA_WITH_3DES_EDE_CBC_SHA":       {sweet32Reason},
 			},
 		},
 		{
 			bad,
 			[]uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA},
 			map[string][]string{
-				"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA": []string{sweet32Reason},
+				"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA": {sweet32Reason},
 			},
 		},
 		{


### PR DESCRIPTION
This just removes some repeated type names that are no longer required
in modern Go.
