### PR TITLE
allow 15 dependabot PRs for Go deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 15
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
The default 5 is pretty low