### PR TITLE
remove deprecated io calls

### DIFF
--- a/allow.go
+++ b/allow.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"expvar"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -312,7 +311,7 @@ type headers struct {
 }
 
 func loadGoogleServiceAccount(fp string) *googleConfig {
-	bs, err := ioutil.ReadFile(fp)
+	bs, err := os.ReadFile(fp)
 	if err != nil {
 		log.Fatalf("unable to read Google service account config %#v: %s", fp, err)
 	}

--- a/gzip/utils_test.go
+++ b/gzip/utils_test.go
@@ -4,18 +4,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 )
-
-func assertTrue(cond bool, msg string, t *testing.T) bool {
-	if !cond {
-		t.Error(msg)
-		return false
-	}
-	return true
-}
 
 func assertStatus(ex, ac int, t *testing.T) {
 	if ex != ac {
@@ -24,7 +15,7 @@ func assertStatus(ex, ac int, t *testing.T) {
 }
 
 func assertBody(ex []byte, res *http.Response, t *testing.T) {
-	buf, err := ioutil.ReadAll(res.Body)
+	buf, err := io.ReadAll(res.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/index_test.go
+++ b/index_test.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -311,7 +311,7 @@ func TestJSONAPI(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Get: %s", err)
 			}
-			b, err := ioutil.ReadAll(resp.Body)
+			b, err := io.ReadAll(resp.Body)
 			defer resp.Body.Close()
 			if err != nil {
 				t.Fatalf("ReadAll: %s", err)

--- a/tls110/tls.go
+++ b/tls110/tls.go
@@ -18,8 +18,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 	"time"
 )
@@ -176,11 +176,11 @@ func Dial(network, addr string, config *Config) (*Conn, error) {
 // form a certificate chain. On successful return, Certificate.Leaf will
 // be nil because the parsed form of the certificate is not retained.
 func LoadX509KeyPair(certFile, keyFile string) (Certificate, error) {
-	certPEMBlock, err := ioutil.ReadFile(certFile)
+	certPEMBlock, err := os.ReadFile(certFile)
 	if err != nil {
 		return Certificate{}, err
 	}
-	keyPEMBlock, err := ioutil.ReadFile(keyFile)
+	keyPEMBlock, err := os.ReadFile(keyFile)
 	if err != nil {
 		return Certificate{}, err
 	}

--- a/tls_test.go
+++ b/tls_test.go
@@ -6,9 +6,9 @@ import (
 	"encoding/pem"
 	"expvar"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
+	"os"
 	"reflect"
 	"strconv"
 	"testing"
@@ -191,7 +191,7 @@ var rootCA *x509.Certificate
 
 func init() {
 	serverConf = makeTLSConfig("./config/development_cert.pem", "./config/development_key.pem")
-	certBytes, err := ioutil.ReadFile("./config/development_ca_cert.pem")
+	certBytes, err := os.ReadFile("./config/development_ca_cert.pem")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
ioutil.ReadAll and ioutil.ReadFile have been deprecated for a few years
now. Fix them up.

Along the way, remove an unused test helper.
