### PR TITLE
remove language about subscriptions

### DIFF
--- a/static/about.html
+++ b/static/about.html
@@ -393,11 +393,6 @@
       <hr />
       <div class="row">
         <div class="col-sm-offset-1 col-sm-12">
-          <h4>Want use the How's My SSL API on your site?  <a href="https://subscriptions.howsmyssl.com">Purchase a subscription</a>!</h4>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-offset-1 col-sm-12">
           Built by <a href="https://www.darkishgreen.com">Darkish Green</a>.
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -285,12 +285,7 @@
           </div>
         </div>
       </div>
-      
-      <div class="row">
-        <div class="col-sm-offset-1 col-sm-12">
-          <h4>Want use the How's My SSL API on your site?  <a href="https://subscriptions.howsmyssl.com">Purchase a subscription</a>!</h4>
-        </div>
-      </div>
+
       <div class="row">
         <div class="col-sm-offset-1 col-sm-12">
           Built by <a href="https://www.darkishgreen.com">Darkish Green</a>.


### PR DESCRIPTION
I've no longer been accepting new subscriptions and long ago cancel the
existing ones. Not enough time to manage the customer relationships.

So, we remove the references to it. Maybe some day in the future, but
not now.
