### PR TITLE
use atomic generics

### DIFF
--- a/allow_test.go
+++ b/allow_test.go
@@ -4,6 +4,7 @@ import (
 	"expvar"
 	"fmt"
 	"net/http"
+	"sync/atomic"
 	"testing"
 )
 
@@ -21,7 +22,7 @@ func TestOriginAllowerWithLocalhost(t *testing.T) {
 		AllowSubdomainsOn: make(map[string]bool),
 		BlockedDomains:    map[string]bool{"localhost": true, "example.com": true},
 	}
-	ama := &allowMapsAtomic{}
+	ama := &atomic.Pointer[allowMaps]{}
 	ama.Store(am)
 	oa := newOriginAllower(ama, "testhostname", nullLogClient{}, new(expvar.Map).Init(), newTestLogger(t))
 
@@ -97,7 +98,7 @@ func TestOriginAllowerNoLocalhost(t *testing.T) {
 		AllowSubdomainsOn: make(map[string]bool),
 		BlockedDomains:    map[string]bool{"example.com": true},
 	}
-	ama := &allowMapsAtomic{}
+	ama := &atomic.Pointer[allowMaps]{}
 	ama.Store(am)
 	oa := newOriginAllower(ama, "testhostname", nullLogClient{}, new(expvar.Map).Init(), newTestLogger(t))
 

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -118,7 +119,7 @@ func main() {
 		AllowSubdomainsOn: make(map[string]bool),
 		BlockedDomains:    make(map[string]bool),
 	}
-	ama := &allowMapsAtomic{}
+	ama := &atomic.Pointer[allowMaps]{}
 	ama.Store(am)
 	if *allowListsFile != "" {
 		am, err := loadAllowMaps(*allowListsFile)

--- a/index_test.go
+++ b/index_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -225,7 +226,7 @@ func TestJSONAPI(t *testing.T) {
 		AllowSubdomainsOn: make(map[string]bool),
 		BlockedDomains:    map[string]bool{"blocked.com": true},
 	}
-	ama := &allowMapsAtomic{}
+	ama := &atomic.Pointer[allowMaps]{}
 	ama.Store(am)
 	oa := newOriginAllower(ama, "testhostname", nullLogClient{}, new(expvar.Map).Init(), newTestLogger(t))
 	tm := tlsMux("", "www.howsmyssl.com", "www.howsmyssl.com", staticHandler, webHandleFunc, oa, newTestLogger(t), newTestLogger(t))


### PR DESCRIPTION
We use atomic.Pointer instead of the homegrown `allowMapsAtomic` type
that was made to avoid type conversions in various places.

Similarly, a `handshakeCounted` becomes an atomic.Bool instead of a
`int32` that has CompareAndSwapInt32 called on it.

Nice lil improvements.

handshakeCounted becomes an atomic.Bool
