### PR TITLE
modernize Go code automatically with `modernize`

### DIFF
--- a/allow.go
+++ b/allow.go
@@ -49,12 +49,12 @@ func newOriginAllower(ama *atomic.Pointer[allowMaps], hostname string, gclog log
 	topKOfflistDomains := topk.New(100)
 	lifetime := new(expvar.Map).Init()
 	ns.Set("lifetime", lifetime)
-	lifetime.Set("top_all_domains", expvar.Func(func() interface{} {
+	lifetime.Set("top_all_domains", expvar.Func(func() any {
 		metricsMu.RLock()
 		defer metricsMu.RUnlock()
 		return topKAllDomains.Keys()
 	}))
-	lifetime.Set("top_offlist_domains", expvar.Func(func() interface{} {
+	lifetime.Set("top_offlist_domains", expvar.Func(func() any {
 		metricsMu.RLock()
 		defer metricsMu.RUnlock()
 		return topKOfflistDomains.Keys()

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -78,10 +78,10 @@ func main() {
 	t := time.Now()
 	expvar.NewInt("start_time_epoch_secs").Set(t.Unix())
 	expvar.NewString("start_time_timestamp").Set(t.Format(time.RFC3339))
-	expvar.Publish("uptime_secs", expvar.Func(func() interface{} {
+	expvar.Publish("uptime_secs", expvar.Func(func() any {
 		return int64(time.Since(t) / time.Second)
 	}))
-	expvar.Publish("uptime_dur", expvar.Func(func() interface{} {
+	expvar.Publish("uptime_dur", expvar.Func(func() any {
 		return time.Since(t).String()
 	}))
 
@@ -370,7 +370,7 @@ func disallowedRenderJSON(r *http.Request, data *clientInfo) ([]byte, int, strin
 	sanitizedCallback := nonAlphaNumeric.ReplaceAll([]byte(callback), []byte(""))
 
 	if len(sanitizedCallback) != 0 {
-		body := []byte(fmt.Sprintf("%s(%s);", sanitizedCallback, disallowedOriginBody))
+		body := fmt.Appendf(nil, "%s(%s);", sanitizedCallback, disallowedOriginBody)
 		// Browsers won't run this code unless the status is OK.
 		return body, http.StatusOK, "application/javascript", nil
 
@@ -387,7 +387,7 @@ func allowedRenderJSON(r *http.Request, data *clientInfo) ([]byte, int, string, 
 		return nil, 0, htmlContentType, err
 	}
 	if len(sanitizedCallback) > 0 {
-		return []byte(fmt.Sprintf("%s(%s);", sanitizedCallback, marshalled)), http.StatusOK, "application/javascript", nil
+		return fmt.Appendf(nil, "%s(%s);", sanitizedCallback, marshalled), http.StatusOK, "application/javascript", nil
 	}
 
 	return marshalled, http.StatusOK, "application/json", nil

--- a/tls_test.go
+++ b/tls_test.go
@@ -241,7 +241,7 @@ func connect(t *testing.T, clientConf *tls.Config) *conn {
 		ch <- connRes{recv: b, conn: tc}
 	}()
 	var c *tls.Conn
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		d := &net.Dialer{
 			Timeout: 500 * time.Millisecond,
 		}


### PR DESCRIPTION
Updated the code base to a more modern style with automated tooling.

Ran

```
$ go install golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@v0.18.1
$ modernize -fix .
$ modernize -fix ./gendevcerts ./gzip
```

We're ignoring the tls110 package for now since it's a fork.
