### PR TITLE
port client-side TLS in test to zcrypto/tls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/zmap/zcrypto v0.0.0-20260410020656-f1177f7dea82
 	golang.org/x/crypto v0.49.0
-	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/net v0.52.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/api v0.275.0
@@ -45,3 +44,5 @@ require (
 	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+replace github.com/zmap/zcrypto => github.com/jmhodges/zcrypto v0.0.0-20260411041029-ed21bbbb6030

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.14 h1:yh8ncqsbUY4shRD5dA
 github.com/googleapis/enterprise-certificate-proxy v0.3.14/go.mod h1:vqVt9yG9480NtzREnTlmGSBmFrA+bzb0yl0TxoBQXOg=
 github.com/googleapis/gax-go/v2 v2.21.0 h1:h45NjjzEO3faG9Lg/cFrBh2PgegVVgzqKzuZl/wMbiI=
 github.com/googleapis/gax-go/v2 v2.21.0/go.mod h1:But/NJU6TnZsrLai/xBAQLLz+Hc7fHZJt/hsCz3Fih4=
+github.com/jmhodges/zcrypto v0.0.0-20260411041029-ed21bbbb6030 h1:tZOMXdLywmfTF1LiQwKDgsbWzIE4QpsG4HyLyyACrDs=
+github.com/jmhodges/zcrypto v0.0.0-20260411041029-ed21bbbb6030/go.mod h1:9y/jn+HVkT5tGgFebbi2bb8OHyU8q1TX4OGj0M8bsHg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -62,8 +64,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/weppos/publicsuffix-go v0.50.3 h1:eT5dcjHQcVDNc0igpFEsGHKIip30feuB2zuuI9eJxiE=
 github.com/weppos/publicsuffix-go v0.50.3/go.mod h1:/rOa781xBykZhHK/I3QeHo92qdDKVmKZKF7s8qAEM/4=
-github.com/zmap/zcrypto v0.0.0-20260410020656-f1177f7dea82 h1:6P5C5HIjCclJBqgiBgzszcsNZ+t57ZvB8bHNj+QOsDs=
-github.com/zmap/zcrypto v0.0.0-20260410020656-f1177f7dea82/go.mod h1:9y/jn+HVkT5tGgFebbi2bb8OHyU8q1TX4OGj0M8bsHg=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
@@ -84,8 +84,6 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=

--- a/index_test.go
+++ b/index_test.go
@@ -3,14 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"expvar"
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,6 +19,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	tls110 "github.com/jmhodges/howsmyssl/tls110"
+	ztls "github.com/zmap/zcrypto/tls"
 )
 
 type testWriter struct {
@@ -250,21 +249,22 @@ func TestJSONAPI(t *testing.T) {
 	defer srv.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
+
+	tlsConf := &ztls.Config{
+		MaxVersion: ztls.VersionTLS12,
+	}
+	err = configureZTLSConfig(tlsConf)
+	if err != nil {
+		t.Fatalf("configureZTLSConfig: %s", err)
+	}
 	c := &http.Client{
 		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-				DualStack: true,
+			DialTLSContext: (&ztls.Dialer{
+				Config: tlsConf,
 			}).DialContext,
 			MaxIdleConns:          100,
 			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
 		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return errors.New("no redirects should be seen")
@@ -343,5 +343,5 @@ func TestJSONAPI(t *testing.T) {
 }
 
 const (
-	expectedJSONBody = `{"given_cipher_suites":["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256","TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256","TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA","TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA","TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA","TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA","TLS_AES_128_GCM_SHA256","TLS_AES_256_GCM_SHA384","TLS_CHACHA20_POLY1305_SHA256"],"ephemeral_keys_supported":true,"session_ticket_supported":false,"tls_compression_supported":false,"unknown_cipher_suite_supported":false,"beast_vuln":false,"able_to_detect_n_minus_one_splitting":false,"insecure_cipher_suites":{},"tls_version":"TLS 1.3","rating":"Probably Okay"}`
+	expectedJSONBody = `{"given_cipher_suites":["TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256","TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA","TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA","TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA","TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA","TLS_RSA_WITH_AES_128_GCM_SHA256","TLS_RSA_WITH_AES_256_GCM_SHA384","TLS_RSA_WITH_AES_128_CBC_SHA","TLS_RSA_WITH_AES_256_CBC_SHA","TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA","TLS_RSA_WITH_3DES_EDE_CBC_SHA"],"ephemeral_keys_supported":true,"session_ticket_supported":true,"tls_compression_supported":false,"unknown_cipher_suite_supported":false,"beast_vuln":false,"able_to_detect_n_minus_one_splitting":false,"insecure_cipher_suites":{},"tls_version":"TLS 1.2","rating":"Probably Okay"}`
 )

--- a/tls_test.go
+++ b/tls_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bytes"
+	gotls "crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
+
 	"expvar"
 	"io"
 	"log"
@@ -13,16 +16,19 @@ import (
 	"testing"
 	"time"
 
+	zx509 "github.com/zmap/zcrypto/x509"
+
 	"github.com/google/go-cmp/cmp"
 
-	tls "github.com/jmhodges/howsmyssl/tls110"
+	tls110 "github.com/jmhodges/howsmyssl/tls110"
+	ztls "github.com/zmap/zcrypto/tls"
 )
 
 func TestBEASTVuln(t *testing.T) {
 	t.Run("TLS10OnlyCBC", func(t *testing.T) {
-		clientConf := &tls.Config{
-			MaxVersion:   tls.VersionTLS10,
-			CipherSuites: []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA},
+		clientConf := &ztls.Config{
+			MaxVersion:   ztls.VersionTLS10,
+			CipherSuites: []uint16{tls110.TLS_RSA_WITH_AES_128_CBC_SHA},
 		}
 
 		c := connect(t, clientConf)
@@ -45,9 +51,9 @@ func TestBEASTVuln(t *testing.T) {
 	// AbleToDetectNMinusOneSplitting shouldn't be set unless there are BEAST vuln cipher suites included
 	// and we're talking over TLS 1.0.
 	t.Run("TLS10NoCBC", func(t *testing.T) {
-		clientConf := &tls.Config{
-			MaxVersion:   tls.VersionTLS10,
-			CipherSuites: []uint16{tls.TLS_RSA_WITH_RC4_128_SHA},
+		clientConf := &ztls.Config{
+			MaxVersion:   ztls.VersionTLS10,
+			CipherSuites: []uint16{tls110.TLS_RSA_WITH_RC4_128_SHA},
 		}
 		c := connect(t, clientConf)
 		st := c.ConnectionState()
@@ -64,8 +70,8 @@ func TestBEASTVuln(t *testing.T) {
 	})
 
 	t.Run("TLS12NoCBC", func(t *testing.T) {
-		clientConf := &tls.Config{
-			CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305},
+		clientConf := &ztls.Config{
+			CipherSuites: []uint16{tls110.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305},
 		}
 
 		c := connect(t, clientConf)
@@ -87,8 +93,8 @@ func TestBEASTVuln(t *testing.T) {
 // but, instead, we assume the client is "Probably Okay" and look to see that we
 // can handle that golden path.
 func TestGoDefaultIsOkay(t *testing.T) {
-	clientConf := &tls.Config{}
-	c := connect(t, clientConf)
+	clientConf := &gotls.Config{}
+	c := connectGoTLS(t, clientConf)
 	ci := pullClientInfo(c)
 	t.Logf("%#v", ci)
 
@@ -123,14 +129,14 @@ func TestSweet32(t *testing.T) {
 	// GREASE, etc. In order to support testing this behavior, we had to
 	// hardcode into tls110/handshake_client.go the meta ciphersuites we support
 	// here to pass them to the server without dropping them like the client
-	// usually would.  We don't use the tls110 client code anywhere but in these
-	// tests, so this isn't so bad.
+	// usually would. The GREASE and renegotiation test cases (3 and 4) use
+	// connectGoTLS because zcrypto strips those values from the ClientHello.
 	greaseCS := uint16(0x0A0A)
 	renegCS := uint16(0x00FF)
 	tests := []sweetTest{
 		{
 			bad,
-			[]uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
+			[]uint16{tls110.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls110.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, tls110.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls110.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls110.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
 			map[string][]string{
 				"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA": {sweet32Reason},
 				"TLS_RSA_WITH_3DES_EDE_CBC_SHA":       {sweet32Reason},
@@ -138,34 +144,37 @@ func TestSweet32(t *testing.T) {
 		},
 		{
 			bad,
-			[]uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA},
+			[]uint16{tls110.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls110.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, tls110.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls110.TLS_RSA_WITH_3DES_EDE_CBC_SHA},
 			map[string][]string{
 				"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA": {sweet32Reason},
 			},
 		},
 		{
 			okay,
-			[]uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA},
+			[]uint16{tls110.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls110.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls110.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls110.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls110.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA},
 			map[string][]string{},
 		},
 		{
 			okay,
-			[]uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, greaseCS},
+			[]uint16{tls110.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls110.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls110.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls110.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls110.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, greaseCS},
 			map[string][]string{},
 		},
 		{
 			okay,
-			[]uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, greaseCS, renegCS},
+			[]uint16{tls110.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls110.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls110.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls110.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls110.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, greaseCS, renegCS},
 			map[string][]string{},
 		},
 	}
 	for i, st := range tests {
 		t.Run(strconv.Itoa(i),
 			func(t *testing.T) {
-				clientConf := &tls.Config{
+				var c *conn
+				clientConf := &ztls.Config{
+					MaxVersion:   ztls.VersionTLS12,
 					CipherSuites: st.suites,
+					ForceSuites:  true, // Forces the GREASE and SWEET32 ciphersuites to be included in the ClientHello even when not supported
 				}
-				c := connect(t, clientConf)
+				c = connect(t, clientConf)
 				ci := pullClientInfo(c)
 				t.Logf("#%d, %#v", i, ci)
 
@@ -187,7 +196,7 @@ func TestSweet32(t *testing.T) {
 	}
 }
 
-var serverConf *tls.Config
+var serverConf *tls110.Config
 var rootCA *x509.Certificate
 
 func init() {
@@ -205,18 +214,29 @@ func init() {
 	rootCA = certs[0]
 }
 
-func connect(t *testing.T, clientConf *tls.Config) *conn {
+func configureZTLSConfig(clientConf *ztls.Config) error {
 	clientConf.ServerName = "localhost"
 
 	// Required to flip on session ticket keys
-	clientConf.ClientSessionCache = tls.NewLRUClientSessionCache(-1)
+	clientConf.ClientSessionCache = ztls.NewLRUClientSessionCache(-1)
 
 	// Required to avoid InsecureSkipVerify (which is probably unnecessary, but
 	// nice to be Good™.)
-	clientConf.RootCAs = x509.NewCertPool()
-	clientConf.RootCAs.AddCert(rootCA)
+	clientConf.RootCAs = zx509.NewCertPool()
+	zRootCA, err := zx509.ParseCertificate(rootCA.Raw)
+	if err != nil {
+		return fmt.Errorf("zx509.ParseCertificate: %s", err)
+	}
+	clientConf.RootCAs.AddCert(zRootCA)
+	return nil
+}
 
-	tl, err := tls.Listen("tcp", "localhost:0", serverConf)
+func connect(t *testing.T, clientConf *ztls.Config) *conn {
+	if err := configureZTLSConfig(clientConf); err != nil {
+		t.Fatalf("configureZTLSConfig: %s", err)
+	}
+
+	tl, err := tls110.Listen("tcp", "localhost:0", serverConf)
 	if err != nil {
 		t.Fatalf("NewListener: %s", err)
 	}
@@ -244,12 +264,101 @@ func connect(t *testing.T, clientConf *tls.Config) *conn {
 		tc := c.(*conn)
 		ch <- connRes{recv: b, conn: tc}
 	}()
-	var c *tls.Conn
+	var c *ztls.Conn
 	for i := range 10 {
 		d := &net.Dialer{
 			Timeout: 500 * time.Millisecond,
 		}
-		c, err = tls.DialWithDialer(d, "tcp", li.Addr().String(), clientConf)
+		rawConn, dialErr := d.DialContext(t.Context(), "tcp", li.Addr().String())
+		if dialErr != nil {
+			err = dialErr
+		} else {
+			c = ztls.Client(rawConn, clientConf)
+			if hsErr := c.Handshake(); hsErr != nil {
+				rawConn.Close()
+				c = nil
+				err = hsErr
+			} else {
+				err = nil
+			}
+		}
+		if err == nil {
+			break
+		} else {
+			t.Logf("unable to connect on attempt %d: %s", i, err)
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	if err != nil {
+		logErrFromServer(t, errCh)
+		t.Fatalf("Dial: %s", err)
+	}
+	defer c.Close()
+	sent := bytes.Repeat([]byte("a"), bytesLen)
+	_, err = c.Write(sent)
+	if err != nil {
+		logErrFromServer(t, errCh)
+		t.Fatalf("unable to send data to the conn: %s", err)
+	}
+	var cr connRes
+	select {
+	case err := <-errCh:
+		t.Fatalf("Accept: %s", err)
+	case cr = <-ch:
+		if !bytes.Equal(cr.recv, sent) {
+			t.Fatalf("expected bytes %#v, got %#v", string(sent), string(cr.recv))
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out")
+	}
+	return cr.conn
+}
+
+func connectGoTLS(t *testing.T, clientConf *gotls.Config) *conn {
+	clientConf.ServerName = "localhost"
+
+	// Required to flip on session ticket keys
+	clientConf.ClientSessionCache = gotls.NewLRUClientSessionCache(-1)
+
+	// Required to avoid InsecureSkipVerify (which is probably unnecessary, but
+	// nice to be Good™.)
+	clientConf.RootCAs = x509.NewCertPool()
+	clientConf.RootCAs.AddCert(rootCA)
+
+	tl, err := tls110.Listen("tcp", "localhost:0", serverConf)
+	if err != nil {
+		t.Fatalf("NewListener: %s", err)
+	}
+	li := newListener(tl, new(expvar.Map).Init())
+	// bytesLen is picked to be large enough to trigger the BEAST vuln detection
+	// if the client is vulnerable but small enough to not cause too much time
+	// spent in the tests.
+	bytesLen := 256
+	type connRes struct {
+		recv []byte
+		conn *conn
+	}
+	ch := make(chan connRes)
+	errCh := make(chan error)
+	go func() {
+		c, err := li.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		b := make([]byte, bytesLen)
+		io.ReadFull(c, b)
+		c.Close()
+		li.Close()
+		tc := c.(*conn)
+		ch <- connRes{recv: b, conn: tc}
+	}()
+	var c *gotls.Conn
+	for i := range 10 {
+		d := &net.Dialer{
+			Timeout: 500 * time.Millisecond,
+		}
+		c, err = gotls.DialWithDialer(d, "tcp", li.Addr().String(), clientConf)
 		if err == nil {
 			break
 		} else {

--- a/vendor/github.com/zmap/zcrypto/tls/handshake_client.go
+++ b/vendor/github.com/zmap/zcrypto/tls/handshake_client.go
@@ -275,19 +275,23 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, map[CurveID]tls13KeyShare, er
 	possibleCipherSuites := config.cipherSuites()
 	hello.cipherSuites = make([]uint16, 0, len(possibleCipherSuites))
 
-	for _, suiteId := range possibleCipherSuites {
-		for _, suite := range cipherSuites {
-			if suite.id != suiteId {
-				continue
-			}
-			// Don't advertise TLS 1.2-only cipher suites unless
-			// we're attempting TLS 1.2.
-			if hello.vers < VersionTLS12 && suite.flags&suiteTLS12 != 0 {
+	if !config.ForceSuites {
+		for _, suiteId := range possibleCipherSuites {
+			for _, suite := range cipherSuites {
+				if suite.id != suiteId {
+					continue
+				}
+				// Don't advertise TLS 1.2-only cipher suites unless
+				// we're attempting TLS 1.2.
+				if hello.vers < VersionTLS12 && suite.flags&suiteTLS12 != 0 {
+					break
+				}
+				hello.cipherSuites = append(hello.cipherSuites, suiteId)
 				break
 			}
-			hello.cipherSuites = append(hello.cipherSuites, suiteId)
-			break
 		}
+	} else {
+		hello.cipherSuites = append(hello.cipherSuites, possibleCipherSuites...)
 	}
 
 	_, err := io.ReadFull(config.rand(), hello.random)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -105,7 +105,7 @@ github.com/googleapis/gax-go/v2/iterator
 # github.com/weppos/publicsuffix-go v0.50.3
 ## explicit; go 1.24.0
 github.com/weppos/publicsuffix-go/publicsuffix
-# github.com/zmap/zcrypto v0.0.0-20260410020656-f1177f7dea82
+# github.com/zmap/zcrypto v0.0.0-20260410020656-f1177f7dea82 => github.com/jmhodges/zcrypto v0.0.0-20260411041029-ed21bbbb6030
 ## explicit; go 1.25.0
 github.com/zmap/zcrypto/cryptobyte
 github.com/zmap/zcrypto/cryptobyte/asn1
@@ -174,8 +174,6 @@ golang.org/x/crypto/ed25519
 golang.org/x/crypto/hkdf
 golang.org/x/crypto/internal/alias
 golang.org/x/crypto/internal/poly1305
-# golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
-## explicit; go 1.20
 # golang.org/x/net v0.52.0
 ## explicit; go 1.25.0
 golang.org/x/net/http/httpguts
@@ -366,3 +364,4 @@ google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/fieldmaskpb
 google.golang.org/protobuf/types/known/structpb
 google.golang.org/protobuf/types/known/timestamppb
+# github.com/zmap/zcrypto => github.com/jmhodges/zcrypto v0.0.0-20260411041029-ed21bbbb6030


### PR DESCRIPTION
Switch the TLS client code in tests from the fork of 1.10 crypto/tls to
github.com/zmap/zcrypto/tls (well, a fork with a bug fix now). The
server side remains on tls110 to preserve its ClientHello
instrumentation.

We're doing this because we want better control over the variety of
protocols and cipher suites we can test with. The Go crypto/tls library
has (correctly) been removing support for older protocols and cipher
suites, which makes it difficult to test the behavior of clients that
still support those. zcrypto/tls is designed to be expansive in protocol
and cipher suite support, we can maintain that in our tests.

We may also use zcrypto/tls in the future for the server side as well,
but it's not been used much or yet in production that way.

In tls_test.go, we use ztls for the BEAST and Sweet32 test clients, keep
TestGoDefaultIsOkay on the standard library's crypto/tls, and extract
some shared shared config into configureZTLSConfig helper for use in
index_test.go.

In index_test.go, we use ztls.Dialer for the HTTP client's
DialTLSContext, and update expectedJSONBody for zcrypto's support of
session tickets and its default cipher suite perferences.

We make sure to use `ForceSuites` to preserve the ability to test the
Sweet32 vulnerable clients cipher suites are ordered correctly. Handling
meta cipher suites like GREASE (as in the Sweet32 tests) and the
ordering of cipher suites is something we want to trust howsmyssl is
handling correctly.

To do that, we currently have to use a fork of the zcrypto/tls client
code that (at time of writing hopefully) fixes
https://github.com/zmap/zcrypto/issues/485 where ForceSources silently
drops unrecognized client cipher suites.
