### PR TITLE
use log/slog instead of exp/slog

### DIFF
--- a/allow.go
+++ b/allow.go
@@ -6,6 +6,7 @@ import (
 	"expvar"
 	"fmt"
 	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -18,7 +19,6 @@ import (
 	"cloud.google.com/go/logging"
 
 	topk "github.com/dgryski/go-topk"
-	"golang.org/x/exp/slog"
 	"golang.org/x/net/publicsuffix"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -25,7 +26,6 @@ import (
 	"cloud.google.com/go/logging"
 	"github.com/jmhodges/howsmyssl/gzip"
 	tls "github.com/jmhodges/howsmyssl/tls110"
-	"golang.org/x/exp/slog"
 	"google.golang.org/api/option"
 )
 

--- a/index_test.go
+++ b/index_test.go
@@ -9,6 +9,7 @@ import (
 	"expvar"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -20,7 +21,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	tls110 "github.com/jmhodges/howsmyssl/tls110"
-	"golang.org/x/exp/slog"
 )
 
 type testWriter struct {


### PR DESCRIPTION
golang.org/x/exp/slog is now log/slog in the standard library. This
migrates us to it with no change to functionality.
