### PR TITLE
use option.WithAuthCredentialsFile

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -142,7 +142,7 @@ func main() {
 		googConf := loadGoogleServiceAccount(*googAcctConf)
 		client, err := logging.NewClient(ctx,
 			googConf.ProjectID,
-			option.WithCredentialsFile(*googAcctConf),
+			option.WithAuthCredentialsFile(option.ServiceAccount, *googAcctConf),
 		)
 		if err != nil {
 			log.Fatalf("unable to make Google Cloud Logging client: %s", err)


### PR DESCRIPTION
The previous google.golang.org/api/option.WithCredentialsFile() function
is deprecated for security reasons. This commit replaces it with
option.WithAuthCredentialsFile and specifies the auth credential is for
a service account.

Probably we should use a Google service account loaded into the pod for
us on GKE, but this is a minimal change.
