### PR TITLE
remove TLSConfig.BuildNameToCertificate call

### DIFF
--- a/cmd/zclient/zclient.go
+++ b/cmd/zclient/zclient.go
@@ -47,7 +47,7 @@ func main() {
 	conf := &ztls.Config{
 		// TLS 1.0 with CBC suite
 		// MinVersion:         ztls.VersionTLS10,
-		// MaxVersion:         ztls.VersionTLS10,
+		MaxVersion: ztls.VersionTLS10,
 		// CipherSuites:       []uint16{ztls.TLS_RSA_WITH_AES_128_CBC_SHA},
 
 		// TLS 1.3 post-quantum

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -533,7 +533,6 @@ func makeTLSConfig(certPath, keyPath string) *tls.Config {
 			tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
 		},
 	}
-	tlsConf.BuildNameToCertificate()
 	return tlsConf
 }
 


### PR DESCRIPTION
With the keyPairReloader.GetCertificate always returning our single
certificate, there is no need to call BuildNameToCertificate on the
TLSConfig. Removing it also lets us do some experiments with
GetConfigForClient without having to re-parsing and re-building the
certificate on every connection.
