### PR TITLE
in tests, ensure the BEAST vuln is triggered

### DIFF
--- a/tls_test.go
+++ b/tls_test.go
@@ -221,6 +221,10 @@ func connect(t *testing.T, clientConf *tls.Config) *conn {
 		t.Fatalf("NewListener: %s", err)
 	}
 	li := newListener(tl, new(expvar.Map).Init())
+	// bytesLen is picked to be large enough to trigger the BEAST vuln detection
+	// if the client is vulnerable but small enough to not cause too much time
+	// spent in the tests.
+	bytesLen := 256
 	type connRes struct {
 		recv []byte
 		conn *conn
@@ -233,7 +237,7 @@ func connect(t *testing.T, clientConf *tls.Config) *conn {
 			errCh <- err
 			return
 		}
-		b := make([]byte, 1)
+		b := make([]byte, bytesLen)
 		io.ReadFull(c, b)
 		c.Close()
 		li.Close()
@@ -258,7 +262,7 @@ func connect(t *testing.T, clientConf *tls.Config) *conn {
 		t.Fatalf("Dial: %s", err)
 	}
 	defer c.Close()
-	sent := []byte("a")
+	sent := bytes.Repeat([]byte("a"), bytesLen)
 	_, err = c.Write(sent)
 	if err != nil {
 		logErrFromServer(t, errCh)


### PR DESCRIPTION
With TLS clients using a cipher suite and protocols combination
vulnerable to BEAST, we can detect if they mitigate it with the 1/n-1
record splitting. However, we can only detect that if the we send enough
data through the client to trigger the vulnerability.

We were previously sending only 1 byte, which is not enough to trigger
the mitigation. Now we send more.

This larger message size doesn't changes the results for the Go
crypto/tls library (both our forked tls110 version and the modern one)
as they mitigate it. It does change the results for other possible TLS
libraries we're considering using for tests, like
github.com/zmap/zcrypto/tls library. (That one intentionally removed the
1/n-1 record splitting mitigation in order to allow researching NTLM.
See https://github.com/zmap/zcrypto/issues/488)
