### PR TITLE
log if API call includes JSONP callback param

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -427,7 +427,7 @@ func (ah *apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		renderJSON = disallowedRenderJSON
 	}
 
-	ah.allowLogger.InfoContext(r.Context(), "API allowance decision", "detectedDomain", detectedDomain, "allowed", ok, "originHeader", r.Header.Get("Origin"), "referrerHeader", r.Header.Get("Referer"))
+	ah.allowLogger.InfoContext(r.Context(), "API allowance decision", "detectedDomain", detectedDomain, "allowed", ok, "originHeader", r.Header.Get("Origin"), "referrerHeader", r.Header.Get("Referer"), "isJSONP", r.FormValue("callback") != "")
 	handleTLSClientInfo(w, r, apiStatuses, renderJSON)
 }
 


### PR DESCRIPTION
We'd like to remove the JSONP callback param from the API call, and have
clients use CORS, instead. That's a breaking change so we'd like to see
who this would break.
