### PR TITLE
Revert "log if API call includes JSONP callback param (#966)"

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -427,7 +427,7 @@ func (ah *apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		renderJSON = disallowedRenderJSON
 	}
 
-	ah.allowLogger.InfoContext(r.Context(), "API allowance decision", "detectedDomain", detectedDomain, "allowed", ok, "originHeader", r.Header.Get("Origin"), "referrerHeader", r.Header.Get("Referer"), "isJSONP", r.FormValue("callback") != "")
+	ah.allowLogger.InfoContext(r.Context(), "API allowance decision", "detectedDomain", detectedDomain, "allowed", ok, "originHeader", r.Header.Get("Origin"), "referrerHeader", r.Header.Get("Referer"))
 	handleTLSClientInfo(w, r, apiStatuses, renderJSON)
 }
 


### PR DESCRIPTION
This reverts commit d56a9e32c06d2eebd8f71dd099de7fefe1626d48.

We put it in the wrong logger, and, in any case, we can get rough data
by calling `starts_with(httpRequest.requestUrl, "/a/check?callback=")`
in BigQuery.
