### PR TITLE
add ForceSuites to zclient TLS config

### DIFF
--- a/cmd/zclient/zclient.go
+++ b/cmd/zclient/zclient.go
@@ -45,6 +45,8 @@ func main() {
 	}
 
 	conf := &ztls.Config{
+		ForceSuites: true, // Required to test the server-side detection of cipher suites the client doesn't actually support.
+
 		// TLS 1.0 with CBC suite
 		// MinVersion:         ztls.VersionTLS10,
 		MaxVersion: ztls.VersionTLS10,


### PR DESCRIPTION
This is required to test the server-side detection of cipher suites the
zmap zcrypto client doesn't actually support.

 The client will still only use the suites it supports, but it will
 include all of the suites in the ClientHello, allowing us to verify
 that the server correctly identifies unsupported suites.
