### PR TITLE
correct fragment links padding in about.html

### DIFF
--- a/static/about.html
+++ b/static/about.html
@@ -56,8 +56,7 @@
      }
 
      .fragpadded {
-         padding-top: 40px;
-         margin-top: -40px;
+        scroll-margin-top: 70px;
      }
 
      footer {


### PR DESCRIPTION
The links to the sections in the about page were being obscured by the
fixed header even with the attempt in the `fragpadded` CSS class. This
adds nice and modern scroll-margin-top to the relevant elements to fix
that.
