### PR TITLE
correct language around the hybrid pq groups

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -68,7 +68,7 @@ var allNamedGroups = map[uint16]string{
 	0x0103: "ffdhe6144",
 	0x0104: "ffdhe8192",
 
-	// ML-KEM hybrid post-quantum key agreement groups (RFC 9180)
+	// ML-KEM hybrid post-quantum key agreement groups (draft-ietf-tls-ecdhe-mlkem-04)
 	0x11eb: "SecP256r1MLKEM768",
 	0x11ec: "X25519MLKEM768",
 	0x11ed: "SecP384r1MLKEM1024",

--- a/static/about.html
+++ b/static/about.html
@@ -207,11 +207,11 @@
           cryptographically-relevant quantum computers <a
           href="https://www.eff.org/deeplinks/2026/04/yikes-encryptions-y2k-moment-coming-years-early">has
           shifted sooner than expected</a>.</p>
-          <p>Fortunately, we've standardized many of the tools we'll need to
+          <p>Fortunately, we're standardizing many of the tools we'll need to
           defend against them. Among them are the post-quantum key agreement
-          algorithms that were added in TLS 1.3. Key agreement algorithms in TLS
-          allow the client and server to agree on a shared secret that encrypts
-          all further traffic without exposing that secret to attackers
+          algorithms that are being added to TLS 1.3. Key agreement algorithms
+          in TLS allow the client and server to agree on a shared secret that
+          encrypts all further traffic without exposing that secret to attackers
           listening in. The post-quantum key agreement algorithms in TLS 1.3
           ensure that an attacker listening in on that back-and-forth couldn't
           store that data later and decrypt it with a cryptographically-relevant


### PR DESCRIPTION
The hybrid post-quantum key agreement groups are still being
standardized, so we correct the lingo and references.
