### PR TITLE
add hover-revealed anchor links to about.html

### DIFF
--- a/static/about.html
+++ b/static/about.html
@@ -57,6 +57,24 @@
 
      .fragpadded {
         scroll-margin-top: 70px;
+        position: relative;
+     }
+
+     .fragpadded .anchor-link {
+         position: absolute;
+         right: 100%;
+         padding-right: 0.25em;
+         color: #bbb;
+         text-decoration: none;
+         opacity: 0;
+         transition: opacity 0.15s;
+     }
+
+     @media (hover: hover) {
+         .fragpadded:hover .anchor-link,
+         .fragpadded .anchor-link:focus {
+             opacity: 1;
+         }
      }
 
      footer {
@@ -123,7 +141,7 @@
 
           <hr />
 
-          <h3 class="fragpadded" id="rating">Rating</h3>
+          <h3 class="fragpadded" id="rating"><a class="anchor-link" href="#rating" aria-label="Link to Rating">#</a>Rating</h3>
           <p>How's My SSL? gives a rating to each client that connects to
             it. These ratings are not the final word on "how secure" a TLS
             client is, but captures important aspects of its security.</p>
@@ -159,13 +177,13 @@
 
           <hr />
 
-          <h3 class="fragpadded" id="what-it-means">What It Means</h3>
+          <h3 class="fragpadded" id="what-it-means"><a class="anchor-link" href="#what-it-means" aria-label="Link to What It Means">#</a>What It Means</h3>
           <p>How's My SSL has a lot of jargon on it. We're going to discuss the
             sections on its homepage. While it won't help everyone understand all
             of it, those who have a glimmer of an idea of what they mean will be
             better off reading these.</p>
 
-          <h4 class="fragpadded" id="version">Version</h4>
+          <h4 class="fragpadded" id="version"><a class="anchor-link" href="#version" aria-label="Link to Version">#</a>Version</h4>
           <p>The Version section discusses the security of the highest version
             of the TLS protocol your client supports. (Formerly, TLS
             was <a href="#tls-vs-ssl">known as "SSL"</a>.)</p>
@@ -194,7 +212,7 @@
             considered insecure. Clients using it or older versions of SSL will
             be marked as <span class="label bad">Bad</span>.</p>
 
-          <h4 class="fragpadded" id="post-quantum-key-agreement">Post-Quantum Key Agreement</h4>
+          <h4 class="fragpadded" id="post-quantum-key-agreement"><a class="anchor-link" href="#post-quantum-key-agreement" aria-label="Link to Post-Quantum Key Agreement">#</a>Post-Quantum Key Agreement</h4>
           <p>The Post-Quantum Key Agreement section states whether your client
           supports a post-quantum key agreement algorithm that protects shared
           secrets against an attacker with a powerful, future quantum computer.
@@ -236,7 +254,7 @@
           key agreement will be marked as <span class="label
           bad">Bad</span>.</p>
 
-          <h4 class="fragpadded" id="ephemeral-key-support">Ephemeral Key Support</h4>
+          <h4 class="fragpadded" id="ephemeral-key-support"><a class="anchor-link" href="#ephemeral-key-support" aria-label="Link to Ephemeral Key Support">#</a>Ephemeral Key Support</h4>
           <p>The Ephemeral Key Support section says if your client tells
             the service that it supports cipher suites that include an
             additional private key created for each connection to the
@@ -254,7 +272,7 @@
             suites will be defaulted to <span class="label okay">Probably Okay</span>. Clients without it will be
             marked as <span class="label bad">Bad</span>.</p>
 
-          <h4 class="fragpadded" id="session-ticket-support">Session Ticket Support</h4>
+          <h4 class="fragpadded" id="session-ticket-support"><a class="anchor-link" href="#session-ticket-support" aria-label="Link to Session Ticket Support">#</a>Session Ticket Support</h4>
           <p>Session tickets are a mechanism to speed up resumption of encrypted
             communication with a server. When a client and server first connect
             over TLS, they perform a complicated, time-consuming handshake. This
@@ -290,7 +308,7 @@
             but not having it will only have it defaulted to
             <span class="label improvable">Improvable</span>.</p>
 
-          <h4 class="fragpadded" id="tls-compression">TLS Compression</h4>
+          <h4 class="fragpadded" id="tls-compression"><a class="anchor-link" href="#tls-compression" aria-label="Link to TLS Compression">#</a>TLS Compression</h4>
           <p>TLS compression was a specification of a way to make the data in
             the encrypted connection smaller in order to speed up the transfer
             of data across those connections. Unfortunately, applying this
@@ -306,7 +324,7 @@
             that leave it enabled will be marked
             as <span class="label bad">Bad</span>.</p>
 
-          <h4 class="fragpadded" id="beast-vulnerability">BEAST Vulnerability</h4>
+          <h4 class="fragpadded" id="beast-vulnerability"><a class="anchor-link" href="#beast-vulnerability" aria-label="Link to BEAST Vulnerability">#</a>BEAST Vulnerability</h4>
           <p>The <a href="https://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
             vulnerability</a> is an attack on TLS 1.0 connections using a
             cipher suite in a cipher block chaining (CBC) mode. An
@@ -336,7 +354,7 @@
             and clients that do multiple or all of the above, will be marked as
             <span class="label okay">Probably Okay</span>.</p>
 
-          <h4 class="fragpadded" id="insecure-cipher-suites">Insecure Cipher Suites</h4>
+          <h4 class="fragpadded" id="insecure-cipher-suites"><a class="anchor-link" href="#insecure-cipher-suites" aria-label="Link to Insecure Cipher Suites">#</a>Insecure Cipher Suites</h4>
           <p>This section displayed any cipher suites the client supports that
             are known to be insecure. Insecure cipher suites make it easy for
             attackers to decrypt data on tapped lines, or make it easy for the
@@ -378,7 +396,7 @@
           <p>Any client supporting an insecure cipher suite will be marked as
             <span class="label bad">Bad</span>.</p>
 
-          <h4 class="fragpadded" id="unknown-cipher-suites-supported">Unknown Cipher Suites
+          <h4 class="fragpadded" id="unknown-cipher-suites-supported"><a class="anchor-link" href="#unknown-cipher-suites-supported" aria-label="Link to Unknown Cipher Suites Supported">#</a>Unknown Cipher Suites
             Supported</h4>
           <p>This section notes any cipher suites that How's My SSL did not
             recognize. How's My SSL has a very complete knowledge of cipher
@@ -390,7 +408,7 @@
             insecure. Clients supporting unknown cipher suites will be marked
             as <span class="label bad">Bad</span>.</p>
 
-          <h4 class="fragpadded" id="given-cipher-suites">Given Cipher Suites</h4>
+          <h4 class="fragpadded" id="given-cipher-suites"><a class="anchor-link" href="#given-cipher-suites" aria-label="Link to Given Cipher Suites">#</a>Given Cipher Suites</h4>
           <p>This section is one of the most often needed by developers and was
           the original reason this webapp was made. It simply prints out the
           standard names of the cipher suites that the client says it supports
@@ -399,7 +417,7 @@
           TLS servers tend to choose their own preference of those cipher
           suites. No rating will be given in this section.</p>
 
-          <h4 class="fragpadded" id="given-named-groups">Given Named Groups</h4>
+          <h4 class="fragpadded" id="given-named-groups"><a class="anchor-link" href="#given-named-groups" aria-label="Link to Given Named Groups">#</a>Given Named Groups</h4>
           <p>This section is a list of the named groups that the client says it
           supports. Named groups specify the elliptic curves or finite field
           groups for the cipher suites the client supports. The named groups are
@@ -407,7 +425,7 @@
           rating will be given in this section.</p>
 
           <hr />
-          <h3 class="fragpadded" id="tls-vs-ssl">TLS vs SSL</h3>
+          <h3 class="fragpadded" id="tls-vs-ssl"><a class="anchor-link" href="#tls-vs-ssl" aria-label="Link to TLS vs SSL">#</a>TLS vs SSL</h3>
           <p>Okay, last thing. The jargon around this is a little funny, so
           let's be more explicit. The 'S' in "HTTPS" is the TLS protocol. When
           folks refer to the "<a
@@ -426,7 +444,7 @@
 
           <hr />
 
-          <h3 class="fragpadded" id="contributing">Contributing</h3>
+          <h3 class="fragpadded" id="contributing"><a class="anchor-link" href="#contributing" aria-label="Link to Contributing">#</a>Contributing</h3>
           <p>Have feedback? Leave it on
             the <a href="https://groups.google.com/forum/#!forum/howsmyssl-upkeep">howsmyssl-upkeep
             mailing list</a>. Notice a


### PR DESCRIPTION
Each fragpadded section heading now includes a small "#" link in the
left gutter that fades in on hover (desktop only, via @media (hover:
hover)). Clicking it navigates to the section's fragment URL, making it
easy to share links to specific parts of the About page.
