### PR TITLE
use zcrypto/tls for TestSweet32

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,3 +44,5 @@ require (
 	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+replace github.com/zmap/zcrypto => github.com/jmhodges/zcrypto v0.0.0-20260424220243-a45e613e1b4b

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.14 h1:yh8ncqsbUY4shRD5dA
 github.com/googleapis/enterprise-certificate-proxy v0.3.14/go.mod h1:vqVt9yG9480NtzREnTlmGSBmFrA+bzb0yl0TxoBQXOg=
 github.com/googleapis/gax-go/v2 v2.21.0 h1:h45NjjzEO3faG9Lg/cFrBh2PgegVVgzqKzuZl/wMbiI=
 github.com/googleapis/gax-go/v2 v2.21.0/go.mod h1:But/NJU6TnZsrLai/xBAQLLz+Hc7fHZJt/hsCz3Fih4=
+github.com/jmhodges/zcrypto v0.0.0-20260424220243-a45e613e1b4b h1:+UihW4kXQGsW5u6wAlvTZ97lg3KDROAd8cAQ45ZRfJw=
+github.com/jmhodges/zcrypto v0.0.0-20260424220243-a45e613e1b4b/go.mod h1:9y/jn+HVkT5tGgFebbi2bb8OHyU8q1TX4OGj0M8bsHg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -62,10 +64,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/weppos/publicsuffix-go v0.50.3 h1:eT5dcjHQcVDNc0igpFEsGHKIip30feuB2zuuI9eJxiE=
 github.com/weppos/publicsuffix-go v0.50.3/go.mod h1:/rOa781xBykZhHK/I3QeHo92qdDKVmKZKF7s8qAEM/4=
-github.com/zmap/zcrypto v0.0.0-20260410020656-f1177f7dea82 h1:6P5C5HIjCclJBqgiBgzszcsNZ+t57ZvB8bHNj+QOsDs=
-github.com/zmap/zcrypto v0.0.0-20260410020656-f1177f7dea82/go.mod h1:9y/jn+HVkT5tGgFebbi2bb8OHyU8q1TX4OGj0M8bsHg=
-github.com/zmap/zcrypto v0.0.0-20260413215825-aacf0e34cc16 h1:hxpQ57/tgLRAziHn6G9DFEYY9uenJ7PlsNtUqYgW+so=
-github.com/zmap/zcrypto v0.0.0-20260413215825-aacf0e34cc16/go.mod h1:9y/jn+HVkT5tGgFebbi2bb8OHyU8q1TX4OGj0M8bsHg=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/tls110/handshake_client.go
+++ b/tls110/handshake_client.go
@@ -66,13 +66,6 @@ func makeClientHello(config *Config) (*clientHelloMsg, error) {
 NextCipherSuite:
 	for _, suiteId := range possibleCipherSuites {
 		for _, suite := range cipherSuites {
-			// Explicitly whitelisting some meta cipher suites as okay to be
-			// used in TestSweet32 in howsmyssl's client config
-
-			if suiteId == 0x00FF || suiteId == 0x0A0A {
-				hello.cipherSuites = append(hello.cipherSuites, suiteId)
-				continue NextCipherSuite
-			}
 
 			if suite.id != suiteId {
 				continue

--- a/tls_test.go
+++ b/tls_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	tls "github.com/jmhodges/howsmyssl/tls110"
+	ztls "github.com/zmap/zcrypto/tls"
+	zx509 "github.com/zmap/zcrypto/x509"
 )
 
 func TestBEASTVuln(t *testing.T) {
@@ -120,17 +122,16 @@ func TestSweet32(t *testing.T) {
 	// 1.3 ciphersuites are also attached to the end. So, howsmyssl says a
 	// client is vulnerable to Sweet32 if the Sweet32 vulnerable ciphersuites
 	// are last or would be last except for some known meta ciphersuites like
-	// GREASE, etc. In order to support testing this behavior, we had to
-	// hardcode into tls110/handshake_client.go the meta ciphersuites we support
-	// here to pass them to the server without dropping them like the client
-	// usually would.  We don't use the tls110 client code anywhere but in these
-	// tests, so this isn't so bad.
+	// GREASE, etc. In order to support testing this behavior, we use the
+	// zcrypto/tls client with ForceSuites: true so that the client sends the
+	// meta ciphersuites we ask for without dropping them like the client
+	// usually would.
 	greaseCS := uint16(0x0A0A)
 	renegCS := uint16(0x00FF)
 	tests := []sweetTest{
 		{
 			bad,
-			[]uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
+			[]uint16{ztls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, ztls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, ztls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, ztls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, ztls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
 			map[string][]string{
 				"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA": {sweet32Reason},
 				"TLS_RSA_WITH_3DES_EDE_CBC_SHA":       {sweet32Reason},
@@ -138,34 +139,36 @@ func TestSweet32(t *testing.T) {
 		},
 		{
 			bad,
-			[]uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA},
+			[]uint16{ztls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, ztls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, ztls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, ztls.TLS_RSA_WITH_3DES_EDE_CBC_SHA},
 			map[string][]string{
 				"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA": {sweet32Reason},
 			},
 		},
 		{
 			okay,
-			[]uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA},
+			[]uint16{ztls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, ztls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, ztls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, ztls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, ztls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA},
 			map[string][]string{},
 		},
 		{
 			okay,
-			[]uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, greaseCS},
+			[]uint16{ztls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, ztls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, ztls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, ztls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, ztls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, greaseCS},
 			map[string][]string{},
 		},
 		{
 			okay,
-			[]uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, greaseCS, renegCS},
+			[]uint16{ztls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, ztls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, ztls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, ztls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, ztls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, greaseCS, renegCS},
 			map[string][]string{},
 		},
 	}
 	for i, st := range tests {
 		t.Run(strconv.Itoa(i),
 			func(t *testing.T) {
-				clientConf := &tls.Config{
+				clientConf := &ztls.Config{
+					MaxVersion:   ztls.VersionTLS12,
 					CipherSuites: st.suites,
+					ForceSuites:  true,
 				}
-				c := connect(t, clientConf)
+				c := connectZtls(t, clientConf)
 				ci := pullClientInfo(c)
 				t.Logf("#%d, %#v", i, ci)
 
@@ -235,6 +238,7 @@ func TestPostQuantumDetection(t *testing.T) {
 
 var serverConf *tls.Config
 var rootCA *x509.Certificate
+var rootCAZtls *zx509.Certificate
 
 func init() {
 	serverConf = makeTLSConfig("./config/development_cert.pem", "./config/development_key.pem")
@@ -249,6 +253,12 @@ func init() {
 		log.Fatalf("x509.ParseCertificates: %s", err)
 	}
 	rootCA = certs[0]
+
+	zcerts, err := zx509.ParseCertificates(cblock.Bytes)
+	if err != nil {
+		log.Fatalf("zx509.ParseCertificates: %s", err)
+	}
+	rootCAZtls = zcerts[0]
 }
 
 func connect(t *testing.T, clientConf *tls.Config) *conn {
@@ -296,6 +306,80 @@ func connect(t *testing.T, clientConf *tls.Config) *conn {
 			Timeout: 500 * time.Millisecond,
 		}
 		c, err = tls.DialWithDialer(d, "tcp", li.Addr().String(), clientConf)
+		if err == nil {
+			break
+		} else {
+			t.Logf("unable to connect on attempt %d: %s", i, err)
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	if err != nil {
+		logErrFromServer(t, errCh)
+		t.Fatalf("Dial: %s", err)
+	}
+	defer c.Close()
+	sent := bytes.Repeat([]byte("a"), bytesLen)
+	_, err = c.Write(sent)
+	if err != nil {
+		logErrFromServer(t, errCh)
+		t.Fatalf("unable to send data to the conn: %s", err)
+	}
+	var cr connRes
+	select {
+	case err := <-errCh:
+		t.Fatalf("Accept: %s", err)
+	case cr = <-ch:
+		if !bytes.Equal(cr.recv, sent) {
+			t.Fatalf("expected bytes %#v, got %#v", string(sent), string(cr.recv))
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out")
+	}
+	return cr.conn
+}
+
+func connectZtls(t *testing.T, clientConf *ztls.Config) *conn {
+	clientConf.ServerName = "localhost"
+
+	// Required to flip on session ticket keys
+	clientConf.ClientSessionCache = ztls.NewLRUClientSessionCache(-1)
+
+	// Required to avoid InsecureSkipVerify (which is probably unnecessary, but
+	// nice to be Good™.)
+	clientConf.RootCAs = zx509.NewCertPool()
+	clientConf.RootCAs.AddCert(rootCAZtls)
+
+	tl, err := tls.Listen("tcp", "localhost:0", serverConf)
+	if err != nil {
+		t.Fatalf("NewListener: %s", err)
+	}
+	li := newListener(tl, new(expvar.Map).Init())
+	bytesLen := 256
+	type connRes struct {
+		recv []byte
+		conn *conn
+	}
+	ch := make(chan connRes)
+	errCh := make(chan error)
+	go func() {
+		c, err := li.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		b := make([]byte, bytesLen)
+		io.ReadFull(c, b)
+		c.Close()
+		li.Close()
+		tc := c.(*conn)
+		ch <- connRes{recv: b, conn: tc}
+	}()
+	var c *ztls.Conn
+	for i := range 10 {
+		d := &net.Dialer{
+			Timeout: 500 * time.Millisecond,
+		}
+		c, err = ztls.DialWithDialer(d, "tcp", li.Addr().String(), clientConf)
 		if err == nil {
 			break
 		} else {

--- a/vendor/github.com/zmap/zcrypto/tls/common.go
+++ b/vendor/github.com/zmap/zcrypto/tls/common.go
@@ -903,6 +903,18 @@ type Config struct {
 	// Client-side Only
 	ForceSuites bool
 
+	// DisableTLS10BEASTMitigation, when true, suppresses the 1/(n-1) record
+	// split applied to TLS 1.0 application_data records written over a CBC
+	// cipher. The split randomizes the implicit IV and mitigates the BEAST
+	// chosen-plaintext attack described at
+	// https://www.openssl.org/~bodo/tls-cbc.txt and
+	// https://www.imperialviolet.org/2012/01/15/beastfollowup.html.
+	//
+	// The mitigation is on by default. Set this to true only when
+	// interoperating with a TLS 1.0 peer that mishandles the resulting
+	// 1-byte record (the reason upstream crypto/tls dropped the behavior).
+	DisableTLS10BEASTMitigation bool
+
 	// Export RSA Key
 	ExportRSAKey *rsa.PrivateKey
 
@@ -1054,6 +1066,7 @@ func (c *Config) Clone() *Config {
 		ExplicitCurvePreferences:       c.ExplicitCurvePreferences,
 		SignatureAndHashes:             c.SignatureAndHashes,
 		ForceSuites:                    c.ForceSuites,
+		DisableTLS10BEASTMitigation:    c.DisableTLS10BEASTMitigation,
 		ExportRSAKey:                   c.ExportRSAKey,
 		HeartbeatEnabled:               c.HeartbeatEnabled,
 		ClientDSAEnabled:               c.ClientDSAEnabled,

--- a/vendor/github.com/zmap/zcrypto/tls/conn.go
+++ b/vendor/github.com/zmap/zcrypto/tls/conn.go
@@ -1141,8 +1141,30 @@ func (c *Conn) Write(b []byte) (int, error) {
 		return 0, errShutdown
 	}
 
+	// TLS 1.0 is susceptible to a chosen-plaintext attack when using block
+	// mode ciphers due to predictable IVs. Splitting each Application Data
+	// record into two records effectively randomizes the IV. Applied by
+	// default; opt out via Config.DisableTLS10BEASTMitigation when a TLS 1.0
+	// peer mishandles the resulting 1-byte record (see commit 4f0ea0e for
+	// the interop concern).
+	//
+	// https://www.openssl.org/~bodo/tls-cbc.txt
+	// https://bugzilla.mozilla.org/show_bug.cgi?id=665814
+	// https://www.imperialviolet.org/2012/01/15/beastfollowup.html
+	var m int
+	if len(b) > 1 && c.vers == VersionTLS10 &&
+		(c.config == nil || !c.config.DisableTLS10BEASTMitigation) {
+		if _, ok := c.out.cipher.(cipher.BlockMode); ok {
+			n, err := c.writeRecordLocked(recordTypeApplicationData, b[:1])
+			if err != nil {
+				return n, c.out.setErrorLocked(err)
+			}
+			m, b = 1, b[1:]
+		}
+	}
+
 	n, err := c.writeRecordLocked(recordTypeApplicationData, b)
-	return n, c.out.setErrorLocked(err)
+	return n + m, c.out.setErrorLocked(err)
 }
 
 // handleRenegotiation processes a HelloRequest handshake message.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -106,7 +106,7 @@ github.com/googleapis/gax-go/v2/iterator
 # github.com/weppos/publicsuffix-go v0.50.3
 ## explicit; go 1.24.0
 github.com/weppos/publicsuffix-go/publicsuffix
-# github.com/zmap/zcrypto v0.0.0-20260413215825-aacf0e34cc16
+# github.com/zmap/zcrypto v0.0.0-20260413215825-aacf0e34cc16 => github.com/jmhodges/zcrypto v0.0.0-20260424220243-a45e613e1b4b
 ## explicit; go 1.25.0
 github.com/zmap/zcrypto/cryptobyte
 github.com/zmap/zcrypto/cryptobyte/asn1
@@ -365,3 +365,4 @@ google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/fieldmaskpb
 google.golang.org/protobuf/types/known/structpb
 google.golang.org/protobuf/types/known/timestamppb
+# github.com/zmap/zcrypto => github.com/jmhodges/zcrypto v0.0.0-20260424220243-a45e613e1b4b


### PR DESCRIPTION
We use the github.com/zmap/zcrypto/tls package in TestSweet32 instead of
relying on the patch to tls110's client code that allows specific meta
cipher suites to be passed to the server.

This will allow us to more easily upgrade to newer forks of Go's
crypto/tls by avoiding another patch to track and to be surprised by in
the tests.

However, we have to use a fork of github.com/zmap/zcrypto that includes
a mitigation for the BEAST vulnerability. We are often testing for the
BEAST mitigations, so a library that's vulnerable to it would make
testing for the mitigation existing impossible and for "Probably Okay"
results impossible.

See the PR to add it to the main zcrypto repo for more details
https://github.com/zmap/zcrypto/pull/493

use ztls in TestSweet32 instead of relying on the hack inside the crypto/tls fork to let grease etc go through

remove the explicit whitelisting of some meta ciphersuites in tls110 client code
