### PR TITLE
give tls116 the howsmyssl detection code & use it

### DIFF
--- a/client_info.go
+++ b/client_info.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	tls "github.com/jmhodges/howsmyssl/tls110"
+	tls "github.com/jmhodges/howsmyssl/tls116"
 )
 
 type rating string

--- a/conn.go
+++ b/conn.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"sync/atomic"
 
-	tls "github.com/jmhodges/howsmyssl/tls110"
+	tls "github.com/jmhodges/howsmyssl/tls116"
 )
 
 var (

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -25,7 +25,7 @@ import (
 
 	"cloud.google.com/go/logging"
 	"github.com/jmhodges/howsmyssl/gzip"
-	tls "github.com/jmhodges/howsmyssl/tls110"
+	tls "github.com/jmhodges/howsmyssl/tls116"
 	"google.golang.org/api/option"
 )
 

--- a/index_test.go
+++ b/index_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	tls110 "github.com/jmhodges/howsmyssl/tls110"
+	tls116 "github.com/jmhodges/howsmyssl/tls116"
 )
 
 type testWriter struct {
@@ -236,7 +236,7 @@ func TestJSONAPI(t *testing.T) {
 	oa := newOriginAllower(ama, "testhostname", nullLogClient{}, new(expvar.Map).Init(), newTestLogger(t))
 	tm := tlsMux("", "www.howsmyssl.com", "www.howsmyssl.com", staticHandler, webHandleFunc, oa, newTestLogger(t), newTestLogger(t))
 
-	tl, err := tls110.Listen("tcp", "127.0.0.1:0", serverConf)
+	tl, err := tls116.Listen("tcp", "127.0.0.1:0", serverConf)
 	if err != nil {
 		t.Fatalf("NewListener: %s", err)
 	}

--- a/reloader.go
+++ b/reloader.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	tls "github.com/jmhodges/howsmyssl/tls110"
+	tls "github.com/jmhodges/howsmyssl/tls116"
 )
 
 func newKeypairReloader(certPath, keyPath string) (*keypairReloader, error) {

--- a/tls116/common.go
+++ b/tls116/common.go
@@ -276,6 +276,15 @@ type ConnectionState struct {
 	// RFC 7627, and https://mitls.org/pages/attacks/3SHAKE#channelbindings.
 	TLSUnique []byte
 
+	// Added for howsmyssl's use
+	ClientCipherSuites               []uint16
+	CompressionMethods               []uint8
+	NMinusOneRecordSplittingDetected bool
+	AbleToDetectNMinusOneSplitting   bool
+	SessionTicketsSupported          bool
+	SupportedVersions                []uint16
+	SupportedCurves                  []CurveID
+
 	// ekm is a closure exposed via ExportKeyingMaterial.
 	ekm func(label string, context []byte, length int) ([]byte, error)
 }

--- a/tls116/conn.go
+++ b/tls116/conn.go
@@ -114,6 +114,12 @@ type Conn struct {
 	activeCall int32
 
 	tmp [16]byte
+
+	// Added for howsmyssl's use
+	clientHello                      *clientHelloMsg
+	ableToDetectNMinusOneSplitting   bool
+	readOneAppDataRecord             bool
+	nMinusOneRecordSplittingDetected bool
 }
 
 // Access to net.Conn methods.
@@ -672,6 +678,19 @@ func (c *Conn) readRecordOrCCS(expectChangeCipherSpec bool) error {
 	if typ != recordTypeAlert && typ != recordTypeChangeCipherSpec && len(data) > 0 {
 		// This is a state-advancing message: reset the retry count.
 		c.retryCount = 0
+	}
+
+	// This detects BEAST mitigation when the first app data record is
+	// of length 1 or 0. Length 1 mitigation is common in web browsers, while
+	// length 0 is common in OpenSSL tools. Since the requests to
+	// /a/check are typically very small, this won't detect the Java
+	// style BEAST mitigation where the 1 byte record is sent after
+	// the first application record but only if its large enough.
+	//
+	// TODO(jmhodges): check that 1 or 0 byte records are sent between others
+	if !c.readOneAppDataRecord && c.ableToDetectNMinusOneSplitting && typ == recordTypeApplicationData {
+		c.readOneAppDataRecord = true
+		c.nMinusOneRecordSplittingDetected = len(data) == 1 || len(data) == 0
 	}
 
 	// Handshake messages MUST NOT be interleaved with other record types in TLS 1.3.
@@ -1436,6 +1455,18 @@ func (c *Conn) connectionStateLocked() ConnectionState {
 	} else {
 		state.ekm = c.ekm
 	}
+	if c.clientHello != nil {
+		state.ClientCipherSuites = make([]uint16, len(c.clientHello.cipherSuites))
+		copy(state.ClientCipherSuites, c.clientHello.cipherSuites)
+		state.CompressionMethods = make([]uint8, len(c.clientHello.compressionMethods))
+		copy(state.CompressionMethods, c.clientHello.compressionMethods)
+		state.SessionTicketsSupported = c.clientHello.ticketSupported
+		state.SupportedVersions = c.clientHello.supportedVersions
+		state.SupportedCurves = make([]CurveID, len(c.clientHello.supportedCurves))
+		copy(state.SupportedCurves, c.clientHello.supportedCurves)
+	}
+	state.AbleToDetectNMinusOneSplitting = c.ableToDetectNMinusOneSplitting
+	state.NMinusOneRecordSplittingDetected = c.nMinusOneRecordSplittingDetected
 	return state
 }
 

--- a/tls116/handshake_server.go
+++ b/tls116/handshake_server.go
@@ -42,6 +42,7 @@ func (c *Conn) serverHandshake() error {
 	if err != nil {
 		return err
 	}
+	c.clientHello = clientHello
 
 	if c.vers == VersionTLS13 {
 		hs := serverHandshakeStateTLS13{
@@ -67,7 +68,10 @@ func (hs *serverHandshakeState) handshake() error {
 
 	// For an overview of TLS handshaking, see RFC 5246, Section 7.3.
 	c.buffering = true
-	if hs.checkForResumption() {
+	// Disallow resumption when client is at TLS 1.0 or below so that
+	// we can be sure the checks for HasBeastVulnSuites is set
+	// correctly. A latency and CPU hit, but tolerable for accuracy.
+	if c.vers > VersionTLS10 && hs.checkForResumption() {
 		// The client has included a session ticket and so we do an abbreviated handshake.
 		c.didResume = true
 		if err := hs.doResumeHandshake(); err != nil {
@@ -294,6 +298,24 @@ func supportsECDHE(c *Config, supportedCurves []CurveID, supportedPoints []uint8
 
 func (hs *serverHandshakeState) pickCipherSuite() error {
 	c := hs.c
+
+	// For TLS 1.0 clients, try to select a CBC cipher for BEAST detection.
+	if c.vers <= VersionTLS10 {
+		beastSuites := []uint16{TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_CBC_SHA256}
+		for _, cs := range hs.clientHello.cipherSuites {
+			for _, bs := range beastSuites {
+				if cs == bs {
+					candidate := selectCipherSuite([]uint16{cs}, c.config.cipherSuites(), hs.cipherSuiteOk)
+					if candidate != nil {
+						hs.suite = candidate
+						c.cipherSuite = candidate.id
+						c.ableToDetectNMinusOneSplitting = true
+						return nil
+					}
+				}
+			}
+		}
+	}
 
 	var preferenceList, supportedList []uint16
 	if c.config.PreferServerCipherSuites {

--- a/tls_test.go
+++ b/tls_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	tls "github.com/jmhodges/howsmyssl/tls110"
+	tls "github.com/jmhodges/howsmyssl/tls116"
 	ztls "github.com/zmap/zcrypto/tls"
 	zx509 "github.com/zmap/zcrypto/x509"
 )


### PR DESCRIPTION
This patches the tls116 package to include the feature and vulnerability
detection we have in tls110 and then makes howsmyssl use tls116 instead
of tls110 in howsmyssl. Translated from the tls110 patches in f0d9c758
plus the follow-up for named groups and post-quantum work in
460cb814b83995203fc384a30cae34172016aa16.

Detection changes to tls116:
- Add howsmyssl fields to ConnectionState (ClientCipherSuites,
  CompressionMethods, BEAST detection, session tickets, supported
  versions, supported groups)
- Add BEAST n-minus-one record splitting detection in readRecordOrCCS
- Save clientHello on Conn for both TLS 1.3 and legacy paths
- Disable session resumption for TLS 1.0 for accurate BEAST detection
- Force CBC cipher suite selection for TLS 1.0 clients
