### PR TITLE
remove TLSConfig.NextProtos line

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -505,7 +505,6 @@ func makeTLSConfig(certPath, keyPath string) *tls.Config {
 	go reloadKeypairForever(kpr, time.NewTicker(1*time.Hour))
 	tlsConf := &tls.Config{
 		GetCertificate:           kpr.GetCertificate,
-		NextProtos:               []string{"https"},
 		PreferServerCipherSuites: true,
 		MinVersion:               tls.VersionSSL30,
 		CipherSuites: []uint16{


### PR DESCRIPTION
This line dates all the way back to the original commit, but it was
added in error. This showed up when we started work on porting to a fork
of the Go 1.26.2 crypto/tls package that's more strict about NextProtos
