### PR TITLE
adjust TestBEASTVuln and TestPostQuantumDetection

### DIFF
--- a/tls_test.go
+++ b/tls_test.go
@@ -23,6 +23,7 @@ import (
 func TestBEASTVuln(t *testing.T) {
 	t.Run("TLS10OnlyCBC", func(t *testing.T) {
 		clientConf := &tls.Config{
+			MinVersion:   tls.VersionTLS10,
 			MaxVersion:   tls.VersionTLS10,
 			CipherSuites: []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA},
 		}
@@ -48,6 +49,7 @@ func TestBEASTVuln(t *testing.T) {
 	// and we're talking over TLS 1.0.
 	t.Run("TLS10NoCBC", func(t *testing.T) {
 		clientConf := &tls.Config{
+			MinVersion:   tls.VersionTLS10,
 			MaxVersion:   tls.VersionTLS10,
 			CipherSuites: []uint16{tls.TLS_RSA_WITH_RC4_128_SHA},
 		}
@@ -192,10 +194,14 @@ func TestSweet32(t *testing.T) {
 
 func TestPostQuantumDetection(t *testing.T) {
 	t.Run("WithMLKEM", func(t *testing.T) {
-		clientConf := &tls.Config{
-			CurvePreferences: []tls.CurveID{tls.X25519, 0x11ec},
+		// We've had to reorder the CurvePreferences because crypto/tls (which
+		// our tls library is a fork of) reorders them or drops them if it
+		// doesn't recognize them.
+		clientConf := &ztls.Config{
+			// X25519MLKEM768 is 0x11ec, and not in the stdlib, yet.
+			CurvePreferences: []ztls.CurveID{0x11ec, ztls.X25519},
 		}
-		c := connect(t, clientConf)
+		c := connectZtls(t, clientConf)
 		ci := pullClientInfo(c)
 		t.Logf("%#v", ci)
 
@@ -205,11 +211,11 @@ func TestPostQuantumDetection(t *testing.T) {
 		if len(ci.GivenNamedGroups) != 2 {
 			t.Errorf("GivenNamedGroups length: want 2, got %d (%v)", len(ci.GivenNamedGroups), ci.GivenNamedGroups)
 		}
-		if ci.GivenNamedGroups[0] != "x25519" {
-			t.Errorf("GivenNamedGroups[0]: want x25519, got %s", ci.GivenNamedGroups[0])
+		if ci.GivenNamedGroups[0] != "X25519MLKEM768" {
+			t.Errorf("GivenNamedGroups[0]: want X25519MLKEM768, got %s", ci.GivenNamedGroups[0])
 		}
-		if ci.GivenNamedGroups[1] != "X25519MLKEM768" {
-			t.Errorf("GivenNamedGroups[1]: want X25519MLKEM768, got %s", ci.GivenNamedGroups[1])
+		if ci.GivenNamedGroups[1] != "x25519" {
+			t.Errorf("GivenNamedGroups[1]: want x25519, got %s", ci.GivenNamedGroups[1])
 		}
 	})
 


### PR DESCRIPTION
Two tests were written against tls116 and earlier forks of crypo/tls
defaults that no longer hold in tls1262 (Go 1.26.2), so some adjustments
are needed for that update.

First, TestBEASTVuln/TLS10OnlyCBC and TLS10NoCBC built a client config
with only `MaxVersion: VersionTLS10`. But since Go 1.22,
tls.Config.supportedVersions filters out versions < TLS 1.2 on the
client side unless MinVersion is set explicitly, so the resolved
versions list was empty and the client errored with "no supported
versions satisfy MinVersion and MaxVersion" before it ever dialed. So,
we set `MinVersion: VersionTLS10` explicitly in those tests so the
client actually advertises TLS 1.0.

Second, TestPostQuantumDetection/WithMLKEM expected the client hello to
list named groups in the user-supplied CurvePreferences order ([x25519,
X25519MLKEM768]). In older crypto/tls (like tls116 from 1.16.15),
Config.curvePreferences rejects configs that have name groups (curves)
they don't recognize, even if there are group ids they do recognize
later in the config.CurvePreferences list. In newer crypto/tls from Go
1.24+, curvePreferences reorders the named groups in its own preference
of security, which means the Client Hellos don't match.

Both those of those problems cause TestPostQuantumDetection/WithMLKEM to
fail, of course. So we solve them both by using connectZtls instead of
connect, which uses github.com/zmap/zcrypto/tls, a fork of crypto/tls
that doesn't reorder or drop unrecognized named groups in
CurvePreferences.
