### PR TITLE
add detection code to tls1262 and use it

### DIFF
--- a/client_info.go
+++ b/client_info.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	tls "github.com/jmhodges/howsmyssl/tls116"
+	tls "github.com/jmhodges/howsmyssl/tls1262"
 )
 
 type rating string

--- a/conn.go
+++ b/conn.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"sync/atomic"
 
-	tls "github.com/jmhodges/howsmyssl/tls116"
+	tls "github.com/jmhodges/howsmyssl/tls1262"
 )
 
 var (

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -25,7 +25,7 @@ import (
 
 	"cloud.google.com/go/logging"
 	"github.com/jmhodges/howsmyssl/gzip"
-	tls "github.com/jmhodges/howsmyssl/tls116"
+	tls "github.com/jmhodges/howsmyssl/tls1262"
 	"google.golang.org/api/option"
 )
 

--- a/index_test.go
+++ b/index_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	tls116 "github.com/jmhodges/howsmyssl/tls116"
+	tls116 "github.com/jmhodges/howsmyssl/tls1262"
 )
 
 type testWriter struct {

--- a/reloader.go
+++ b/reloader.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	tls "github.com/jmhodges/howsmyssl/tls116"
+	tls "github.com/jmhodges/howsmyssl/tls1262"
 )
 
 func newKeypairReloader(certPath, keyPath string) (*keypairReloader, error) {

--- a/tls1262/common.go
+++ b/tls1262/common.go
@@ -312,6 +312,15 @@ type ConnectionState struct {
 	// resumed connections that don't support Extended Master Secret (RFC 7627).
 	TLSUnique []byte
 
+	// Added for howsmyssl's use
+	ClientCipherSuites               []uint16
+	CompressionMethods               []uint8
+	NMinusOneRecordSplittingDetected bool
+	AbleToDetectNMinusOneSplitting   bool
+	SessionTicketsSupported          bool
+	SupportedVersions                []uint16
+	SupportedCurves                  []CurveID
+
 	// ECHAccepted indicates if Encrypted Client Hello was offered by the client
 	// and accepted by the server. Currently, ECH is supported only on the
 	// client side.

--- a/tls1262/conn.go
+++ b/tls1262/conn.go
@@ -121,6 +121,12 @@ type Conn struct {
 	activeCall atomic.Int32
 
 	tmp [16]byte
+
+	// Added for howsmyssl's use
+	clientHello                      *clientHelloMsg
+	ableToDetectNMinusOneSplitting   bool
+	readOneAppDataRecord             bool
+	nMinusOneRecordSplittingDetected bool
 }
 
 // Access to net.Conn methods.
@@ -699,6 +705,19 @@ func (c *Conn) readRecordOrCCS(expectChangeCipherSpec bool) error {
 	if typ != recordTypeAlert && typ != recordTypeChangeCipherSpec && len(data) > 0 {
 		// This is a state-advancing message: reset the retry count.
 		c.retryCount = 0
+	}
+
+	// This detects BEAST mitigation when the first app data record is
+	// of length 1 or 0. Length 1 mitigation is common in web browsers, while
+	// length 0 is common in OpenSSL tools. Since the requests to
+	// /a/check are typically very small, this won't detect the Java
+	// style BEAST mitigation where the 1 byte record is sent after
+	// the first application record but only if its large enough.
+	//
+	// TODO(jmhodges): check that 1 or 0 byte records are sent between others
+	if !c.readOneAppDataRecord && c.ableToDetectNMinusOneSplitting && typ == recordTypeApplicationData {
+		c.readOneAppDataRecord = true
+		c.nMinusOneRecordSplittingDetected = len(data) == 1 || len(data) == 0
 	}
 
 	// Handshake messages MUST NOT be interleaved with other record types in TLS 1.3.
@@ -1649,6 +1668,18 @@ func (c *Conn) connectionStateLocked() ConnectionState {
 	} else {
 		state.ekm = c.ekm
 	}
+	if c.clientHello != nil {
+		state.ClientCipherSuites = make([]uint16, len(c.clientHello.cipherSuites))
+		copy(state.ClientCipherSuites, c.clientHello.cipherSuites)
+		state.CompressionMethods = make([]uint8, len(c.clientHello.compressionMethods))
+		copy(state.CompressionMethods, c.clientHello.compressionMethods)
+		state.SessionTicketsSupported = c.clientHello.ticketSupported
+		state.SupportedVersions = c.clientHello.supportedVersions
+		state.SupportedCurves = make([]CurveID, len(c.clientHello.supportedCurves))
+		copy(state.SupportedCurves, c.clientHello.supportedCurves)
+	}
+	state.AbleToDetectNMinusOneSplitting = c.ableToDetectNMinusOneSplitting
+	state.NMinusOneRecordSplittingDetected = c.nMinusOneRecordSplittingDetected
 	state.ECHAccepted = c.echAccepted
 	return state
 }

--- a/tls1262/handshake_server.go
+++ b/tls1262/handshake_server.go
@@ -44,6 +44,7 @@ func (c *Conn) serverHandshake(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	c.clientHello = clientHello
 
 	if c.vers == VersionTLS13 {
 		hs := serverHandshakeStateTLS13{
@@ -74,6 +75,12 @@ func (hs *serverHandshakeState) handshake() error {
 	c.buffering = true
 	if err := hs.checkForResumption(); err != nil {
 		return err
+	}
+	// Disallow resumption when client is at TLS 1.0 or below so that
+	// we can be sure the checks for HasBeastVulnSuites is set
+	// correctly. A latency and CPU hit, but tolerable for accuracy.
+	if c.vers <= VersionTLS10 {
+		hs.sessionState = nil
 	}
 	if hs.sessionState != nil {
 		// The client has included a session ticket and so we do an abbreviated handshake.
@@ -395,6 +402,24 @@ func supportsECDHE(c *Config, version uint16, supportedCurves []CurveID, support
 
 func (hs *serverHandshakeState) pickCipherSuite() error {
 	c := hs.c
+
+	// For TLS 1.0 clients, try to select a CBC cipher for BEAST detection.
+	if c.vers <= VersionTLS10 {
+		beastSuites := []uint16{TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_CBC_SHA256}
+		for _, cs := range hs.clientHello.cipherSuites {
+			for _, bs := range beastSuites {
+				if cs == bs {
+					candidate := selectCipherSuite([]uint16{cs}, c.config.cipherSuites(false), hs.cipherSuiteOk)
+					if candidate != nil {
+						hs.suite = candidate
+						c.cipherSuite = candidate.id
+						c.ableToDetectNMinusOneSplitting = true
+						return nil
+					}
+				}
+			}
+		}
+	}
 
 	preferenceList := c.config.cipherSuites(isAESGCMPreferred(hs.clientHello.cipherSuites))
 

--- a/tls_test.go
+++ b/tls_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	tls "github.com/jmhodges/howsmyssl/tls116"
+	tls "github.com/jmhodges/howsmyssl/tls1262"
 	ztls "github.com/zmap/zcrypto/tls"
 	zx509 "github.com/zmap/zcrypto/x509"
 )


### PR DESCRIPTION
Port of 6ac9903f's tls116 patches onto the tls1262 fork so howsmyssl can
use Go 1.26.2's crypto/tls while keeping the BEAST and feature-detection
behavior live.

Detection changes to tls1262, mirroring the tls116 port:
* Add howsmyssl fields to ConnectionState (ClientCipherSuites,
  CompressionMethods, BEAST detection, session tickets, supported
  versions, supported groups).
* Add BEAST n-minus-one record splitting detection in readRecordOrCCS.
* Save clientHello on Conn for both TLS 1.3 and legacy paths.
* Disable session resumption for TLS 1.0 for accurate BEAST detection.
  Upstream restructured this path: checkForResumption now returns an
  error and stores its result in hs.sessionState, so we null
  hs.sessionState after the call when c.vers <= VersionTLS10 instead of
  short-circuiting the call as tls116 did.
* Force CBC cipher suite selection for TLS 1.0 clients. The only
  signature change is that c.config.cipherSuites now takes an
  aesGCMPreferred bool; pass false since we hand it a single CBC ID.
