### PR TITLE
adjust overflow in "Given" sections

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -63,6 +63,16 @@
          font-size: 1em;
      }
 
+     /* With a grid or flexbox set up, we may not need to reflow the text in the
+     list items, but given Bootstrap v3's creaky grid, this is the best way to
+     prevent the "Given Cipher Suites" section from overlapping the "Given Named
+     Groups" section when the cipher suite names are long. */
+     .col-sm-4 ul li {
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+     }
+
+
      footer {
          margin-bottom: 500px;
      }


### PR DESCRIPTION
The long names of the cipher suites was causing the "Given Cipher
Suites" section to overlap the section next to it.

This is a quick fix to allow the text to wrap the text inside the list
items and prevent the overlap.

I'd really prefer to let the whole lines run, but the pre-grid,
pre-flexbox set up doesn't give us a good way to reflow around them.
Well, at least, I assume a flexbox or grid set up could help us here.
