### PR TITLE
bump min version of TLS server to 1.0 (no-op)

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -506,7 +506,7 @@ func makeTLSConfig(certPath, keyPath string) *tls.Config {
 	tlsConf := &tls.Config{
 		GetCertificate:           kpr.GetCertificate,
 		PreferServerCipherSuites: true,
-		MinVersion:               tls.VersionSSL30,
+		MinVersion:               tls.VersionTLS10,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,


### PR DESCRIPTION
This change actually does nothing. Our tls library stopped supporting
SSLv3 long ago, and the use of SSLv3 as the minimum version was being
rounded up to the TLS 1.0, the next supported version.
