### PR TITLE
have http.Request.TLS set by net/http

### DIFF
--- a/client_info.go
+++ b/client_info.go
@@ -72,7 +72,7 @@ var actualSupportedVersions = map[uint16]string{
 func pullClientInfo(c *conn) *clientInfo {
 	d := &clientInfo{InsecureCipherSuites: make(map[string][]string)}
 
-	st := c.ConnectionState()
+	st := c.Conn.ConnectionState()
 	if !st.HandshakeComplete {
 		panic("given a TLS conn that has not completed its handshake")
 	}

--- a/conn.go
+++ b/conn.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"sync/atomic"
 
+	origtls "crypto/tls"
+
 	tls "github.com/jmhodges/howsmyssl/tls1262"
 )
 
@@ -77,7 +79,7 @@ func (l *listener) Accept() (net.Conn, error) {
 }
 
 type conn struct {
-	*tls.Conn
+	*tls.Conn        // Conn is embedded for net/http to see conn as CloseWriter, HandshakeContext, etc.
 	handshakeCounted *atomic.Bool
 	*handshakeStats
 }
@@ -102,6 +104,34 @@ func (c *conn) Write(b []byte) (int, error) {
 	size, err := c.Conn.Write(b)
 	c.errorToStats(err)
 	return size, err
+}
+
+// ConnectionState is here for the net/http library to set the `Request.TLS`
+// field correctly (its connectionStater interface check). It's not to be called
+// to get the client info. Use pullClientInfo, instead (which looks at the
+// forked version of the ConnectionState with more info).
+//
+// Also, the returned struct's unexported ekm closure is unset, so calling
+// ExportKeyingMaterial on it will panic.
+func (c *conn) ConnectionState() origtls.ConnectionState {
+	cs := c.Conn.ConnectionState()
+	return origtls.ConnectionState{
+		Version:                     cs.Version,
+		HandshakeComplete:           cs.HandshakeComplete,
+		DidResume:                   cs.DidResume,
+		CipherSuite:                 cs.CipherSuite,
+		CurveID:                     origtls.CurveID(cs.CurveID),
+		NegotiatedProtocol:          cs.NegotiatedProtocol,
+		NegotiatedProtocolIsMutual:  cs.NegotiatedProtocolIsMutual,
+		ServerName:                  cs.ServerName,
+		PeerCertificates:            cs.PeerCertificates,
+		VerifiedChains:              cs.VerifiedChains,
+		SignedCertificateTimestamps: cs.SignedCertificateTimestamps,
+		OCSPResponse:                cs.OCSPResponse,
+		TLSUnique:                   cs.TLSUnique,
+		ECHAccepted:                 cs.ECHAccepted,
+		HelloRetryRequest:           cs.HelloRetryRequest,
+	}
 }
 
 func (c *conn) handshake() error {

--- a/tls_test.go
+++ b/tls_test.go
@@ -29,13 +29,6 @@ func TestBEASTVuln(t *testing.T) {
 		}
 
 		c := connect(t, clientConf)
-		st := c.ConnectionState()
-		if !st.AbleToDetectNMinusOneSplitting {
-			t.Errorf("TLS 1.0, CBC suite, Conn: AbleToDetectNMinusOneSplitting was false")
-		}
-		if !st.NMinusOneRecordSplittingDetected {
-			t.Errorf("TLS 1.0, CBC suite, Conn: NMinusOneRecordSplittingDetected was false")
-		}
 		ci := pullClientInfo(c)
 		if ci.BEASTVuln {
 			t.Errorf("TLS 1.0, CBC suite, ClientInfo: BEASTVuln should be false because Go mitigates the BEAST attack even on TLS 1.0")
@@ -54,10 +47,6 @@ func TestBEASTVuln(t *testing.T) {
 			CipherSuites: []uint16{tls.TLS_RSA_WITH_RC4_128_SHA},
 		}
 		c := connect(t, clientConf)
-		st := c.ConnectionState()
-		if st.AbleToDetectNMinusOneSplitting {
-			t.Errorf("TLS 1.0, no CBC suites, Conn: AbleToDetectNMinusOneSplitting was true")
-		}
 		ci := pullClientInfo(c)
 		if ci.BEASTVuln {
 			t.Errorf("TLS 1.0, no CBC suites, ClientInfo: BEASTVuln should be false because Go mitigates the BEAST attack even on TLS 1.0")
@@ -73,10 +62,6 @@ func TestBEASTVuln(t *testing.T) {
 		}
 
 		c := connect(t, clientConf)
-		st := c.ConnectionState()
-		if st.AbleToDetectNMinusOneSplitting {
-			t.Errorf("TLS 1.2+, no CBC suites, Conn: AbleToDetectNMinusOneSplitting was true")
-		}
 		ci := pullClientInfo(c)
 		if ci.BEASTVuln {
 			t.Errorf("TLS 1.2+, no CBC suites, ClientInfo: BEASTVuln should be false because Go mitigates the BEAST attack even on TLS 1.0")


### PR DESCRIPTION
The net/http library checks that there's a ConnectionState method that
returns the exact `crypto/tls.ConnectionState` type, and if so, it calls
it to set the `Request.TLS` field. The previous `ConnectionState` method
on our `conn` wrapper returned the custom `tls1262.ConnectionState`
type, so net/http didn't call it and `Request.TLS` was always nil.

With this change, we'll be able to drop some of our X-Forwarded-For
hacks and use `Request.TLS` in logHandler. That'll happen in a future
change.

Along the way, we drop some parts of tests that were using the prior
`ConnectionState` method and have those test just against the returned
`clientInfo` struct as they already were.

Also, the embedding of `tls.Conn` we do in `conn` already gets us past
the other implicit interface checks in net/http (CloseWriter, and
HandshakeContext in our case), so we don't need to handle those.
