### PR TITLE
smuggle around *tls1262.Conn not *conn

### DIFF
--- a/client_info.go
+++ b/client_info.go
@@ -69,10 +69,10 @@ var actualSupportedVersions = map[uint16]string{
 	versionTLS13Draft33: "TLS 1.3",
 }
 
-func pullClientInfo(c *conn) *clientInfo {
+func pullClientInfo(c *tls.Conn) *clientInfo {
 	d := &clientInfo{InsecureCipherSuites: make(map[string][]string)}
 
-	st := c.Conn.ConnectionState()
+	st := c.ConnectionState()
 	if !st.HandshakeComplete {
 		panic("given a TLS conn that has not completed its handshake")
 	}

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -262,7 +262,7 @@ func configureHTTPSServer(srv *http.Server) {
 		// be performed, and I don't want to lock here waiting for the handshake
 		// to finish. It might be fine, but I've not verified there's nothing
 		// that would be delayed by doing so.
-		ctx = context.WithValue(ctx, smuggledConnKey, tc)
+		ctx = context.WithValue(ctx, smuggledConnKey, tc.Conn)
 		return ctx
 	}
 }
@@ -439,9 +439,9 @@ func handleTLSClientInfo(w http.ResponseWriter, r *http.Request, statuses *statu
 	// formatting ourselves.
 	w = &statWriter{w: w, stats: statuses}
 	c := r.Context().Value(smuggledConnKey)
-	tc, ok := c.(*conn)
+	tc, ok := c.(*tls.Conn)
 	if !ok {
-		log.Printf("handleTLSClientInfo: unable to convert smuggledConnKey to *conn: %#v", c)
+		log.Printf("handleTLSClientInfo: unable to convert smuggledConnKey to *tls.Conn: %#v", c)
 		response500(w, r)
 		return
 	}
@@ -594,7 +594,7 @@ func (h logHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if userAgent == "" {
 		userAgent = "nouseragent"
 	}
-	tlsConn, ok := r.Context().Value(smuggledConnKey).(*conn)
+	tlsConn, ok := r.Context().Value(smuggledConnKey).(*tls.Conn)
 	tlsVersion := "none"
 	if ok && tlsConn != nil {
 		version := tlsConn.ConnectionState().Version

--- a/tls_test.go
+++ b/tls_test.go
@@ -252,7 +252,7 @@ func init() {
 	rootCAZtls = zcerts[0]
 }
 
-func connect(t *testing.T, clientConf *tls.Config) *conn {
+func connect(t *testing.T, clientConf *tls.Config) *tls.Conn {
 	clientConf.ServerName = "localhost"
 
 	// Required to flip on session ticket keys
@@ -326,10 +326,10 @@ func connect(t *testing.T, clientConf *tls.Config) *conn {
 	case <-time.After(1 * time.Second):
 		t.Fatalf("timed out")
 	}
-	return cr.conn
+	return cr.conn.Conn
 }
 
-func connectZtls(t *testing.T, clientConf *ztls.Config) *conn {
+func connectZtls(t *testing.T, clientConf *ztls.Config) *tls.Conn {
 	clientConf.ServerName = "localhost"
 
 	// Required to flip on session ticket keys
@@ -400,7 +400,7 @@ func connectZtls(t *testing.T, clientConf *ztls.Config) *conn {
 	case <-time.After(1 * time.Second):
 		t.Fatalf("timed out")
 	}
-	return cr.conn
+	return cr.conn.Conn
 }
 
 func logErrFromServer(t *testing.T, errCh chan error) {


### PR DESCRIPTION
A future refactoring for http/2 support is going to move conn.go into a
new package. While we're doing that, it became clear it would be more
convenient to pass around the `*tls1262.Conn` instead of the `*conn`
wrapper type. This avoids some future refactoring churn and simplifies
the code a bit.

The tradeoff is that it'll be harder to test metrics code, but we can
test them in the new package.
