### PR TITLE
enable HTTP/2 via new howhttp package

### DIFF
--- a/howhttp/concurrent_test.go
+++ b/howhttp/concurrent_test.go
@@ -1,0 +1,281 @@
+package howhttp_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	howhttptest "github.com/jmhodges/howsmyssl/howhttp/httptest"
+)
+
+const concurrentN = 50
+
+func TestServer_ConcurrentHTTP11(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	srv := howhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, r.URL.Query().Get("token"))
+	}))
+	t.Cleanup(srv.Close)
+
+	var wg sync.WaitGroup
+	errs := make([]error, concurrentN)
+	bodies := make([]string, concurrentN)
+	protos := make([]int, concurrentN)
+	wg.Add(concurrentN)
+	for i := range concurrentN {
+		go func(i int) {
+			defer wg.Done()
+			tlsConf := srv.ClientTLSConfig()
+			tlsConf.NextProtos = []string{"http/1.1"}
+			tr := &http.Transport{TLSClientConfig: tlsConf}
+			defer tr.CloseIdleConnections()
+			c := &http.Client{Transport: tr, Timeout: 10 * time.Second}
+
+			resp, err := c.Get(srv.URL + "/?token=" + strconv.Itoa(i))
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			defer resp.Body.Close()
+			protos[i] = resp.ProtoMajor
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			bodies[i] = string(b)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range errs {
+		if errs[i] != nil {
+			t.Errorf("req %d: %v", i, errs[i])
+			continue
+		}
+		if protos[i] != 1 {
+			t.Errorf("req %d ProtoMajor = %d, want 1", i, protos[i])
+		}
+		if want := strconv.Itoa(i); bodies[i] != want {
+			t.Errorf("req %d body = %q, want %q", i, bodies[i], want)
+		}
+	}
+}
+
+func TestServer_ConcurrentHTTP2_Multiplexed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	srv := howhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Force temporal overlap so requests actually share the connection
+		// rather than serializing.
+		time.Sleep(10 * time.Millisecond)
+		io.WriteString(w, r.URL.Query().Get("token"))
+	}))
+	t.Cleanup(srv.Close)
+	c := srv.Client() // single shared client => one multiplexed h2 conn
+
+	var wg sync.WaitGroup
+	errs := make([]error, concurrentN)
+	bodies := make([]string, concurrentN)
+	protos := make([]int, concurrentN)
+	wg.Add(concurrentN)
+	for i := range concurrentN {
+		go func(i int) {
+			defer wg.Done()
+			resp, err := c.Get(srv.URL + "/?token=" + strconv.Itoa(i))
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			defer resp.Body.Close()
+			protos[i] = resp.ProtoMajor
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			bodies[i] = string(b)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range errs {
+		if errs[i] != nil {
+			t.Errorf("req %d: %v", i, errs[i])
+			continue
+		}
+		if protos[i] != 2 {
+			t.Errorf("req %d ProtoMajor = %d, want 2", i, protos[i])
+		}
+		if want := strconv.Itoa(i); bodies[i] != want {
+			t.Errorf("req %d body = %q, want %q", i, bodies[i], want)
+		}
+	}
+}
+
+func TestServer_ConcurrentHTTP2_ManyConns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	srv := howhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, r.URL.Query().Get("token"))
+	}))
+	t.Cleanup(srv.Close)
+
+	var wg sync.WaitGroup
+	errs := make([]error, concurrentN)
+	bodies := make([]string, concurrentN)
+	protos := make([]int, concurrentN)
+	wg.Add(concurrentN)
+	for i := range concurrentN {
+		go func(i int) {
+			defer wg.Done()
+			tr := &http.Transport{
+				TLSClientConfig:   srv.ClientTLSConfig(),
+				ForceAttemptHTTP2: true,
+			}
+			defer tr.CloseIdleConnections()
+			c := &http.Client{Transport: tr, Timeout: 10 * time.Second}
+
+			resp, err := c.Get(srv.URL + "/?token=" + strconv.Itoa(i))
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			defer resp.Body.Close()
+			protos[i] = resp.ProtoMajor
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			bodies[i] = string(b)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range errs {
+		if errs[i] != nil {
+			t.Errorf("req %d: %v", i, errs[i])
+			continue
+		}
+		if protos[i] != 2 {
+			t.Errorf("req %d ProtoMajor = %d, want 2", i, protos[i])
+		}
+		if want := strconv.Itoa(i); bodies[i] != want {
+			t.Errorf("req %d body = %q, want %q", i, bodies[i], want)
+		}
+	}
+}
+
+func TestServer_ShutdownDrainsInFlight(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	// Each handler signals it has entered, sleeps long enough that all N
+	// are guaranteed to be in-flight when we call Shutdown, then returns
+	// 200. A correct Shutdown waits for every one of these to complete.
+	const handlerSleep = 200 * time.Millisecond
+	// Generous deadline: under `go test -race` with N concurrent in-flight
+	// requests, drain has been observed to take well over 5s on a loaded
+	// machine. The test verifies that Shutdown drains successfully, not
+	// how quickly.
+	const shutdownTimeout = 30 * time.Second
+
+	handlerEntered := make(chan struct{}, concurrentN)
+	srv := howhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerEntered <- struct{}{}
+		time.Sleep(handlerSleep)
+		io.WriteString(w, "ok")
+	}))
+	t.Cleanup(srv.Close)
+
+	var wg sync.WaitGroup
+	errs := make([]error, concurrentN)
+	bodies := make([]string, concurrentN)
+
+	h2Client := srv.Client() // shared h2 client for odd indices
+	wg.Add(concurrentN)
+	for i := range concurrentN {
+		go func(i int) {
+			defer wg.Done()
+			var c *http.Client
+			if i%2 == 0 {
+				tlsConf := srv.ClientTLSConfig()
+				tlsConf.NextProtos = []string{"http/1.1"}
+				tr := &http.Transport{TLSClientConfig: tlsConf}
+				defer tr.CloseIdleConnections()
+				c = &http.Client{Transport: tr, Timeout: 10 * time.Second}
+			} else {
+				c = h2Client
+			}
+			resp, err := c.Get(srv.URL + "/")
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			defer resp.Body.Close()
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			bodies[i] = string(b)
+		}(i)
+	}
+
+	for i := range concurrentN {
+		select {
+		case <-handlerEntered:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("only %d/%d handlers entered before timeout", i, concurrentN)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if err := srv.Config.Shutdown(ctx); err != nil {
+		t.Errorf("Shutdown returned %v, want nil (drain should have completed in time)", err)
+	}
+
+	wg.Wait()
+	for i := range errs {
+		if errs[i] != nil {
+			t.Errorf("req %d: %v", i, errs[i])
+			continue
+		}
+		if bodies[i] != "ok" {
+			t.Errorf("req %d body = %q, want %q", i, bodies[i], "ok")
+		}
+	}
+}
+
+func BenchmarkServer_ConcurrentH2(b *testing.B) {
+	srv := howhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	b.Cleanup(srv.Close)
+	c := srv.Client()
+	url := srv.URL + "/"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			resp, err := c.Get(url)
+			if err != nil {
+				b.Error(err)
+				return
+			}
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	})
+}

--- a/howhttp/conn.go
+++ b/howhttp/conn.go
@@ -1,4 +1,7 @@
-package main
+// Package howhttp provides the custom HTTP/1.x and HTTP/2 server plumbing that
+// howsmyssl uses to serve requests over its forked tls1262 stack while still
+// reusing net/http and golang.org/x/net/http2.
+package howhttp
 
 import (
 	"errors"
@@ -14,12 +17,12 @@ import (
 )
 
 var (
-	_              net.Listener = &listener{}
-	_              net.Conn     = &conn{}
-	errTLSConnConv              = errors.New("Unable to convert net.Conn to tls.Conn")
+	_              net.Listener = &Listener{}
+	_              net.Conn     = &Conn{}
+	errTLSConnConv              = errors.New("unable to convert net.Conn to *tls1262.Conn")
 )
 
-type listener struct {
+type Listener struct {
 	net.Listener
 	*handshakeStats
 }
@@ -50,35 +53,35 @@ func newHandshakeStats(ns *expvar.Map) *handshakeStats {
 	ns.Set("eofs", s.EOFs)
 	return s
 }
-func newListener(nl net.Listener, ns *expvar.Map) *listener {
+
+func NewListener(nl net.Listener, ns *expvar.Map) *Listener {
 	statNS := new(expvar.Map).Init()
 	ns.Set("handshake", statNS)
-	lis := &listener{
+	lis := &Listener{
 		Listener:       nl,
 		handshakeStats: newHandshakeStats(statNS),
 	}
 	return lis
 }
 
-func (l *listener) Accept() (net.Conn, error) {
+func (l *Listener) Accept() (net.Conn, error) {
 	c, err := l.Listener.Accept()
 	if err != nil {
 		return c, err
-
 	}
 	tlsConn, ok := c.(*tls.Conn)
 	if !ok {
 		c.Close()
 		return nil, errTLSConnConv
 	}
-	return &conn{
+	return &Conn{
 		Conn:           tlsConn,
 		handshakeStats: l.handshakeStats,
 	}, nil
 }
 
-type conn struct {
-	*tls.Conn // Conn is embedded for net/http to see conn as CloseWriter, HandshakeContext, etc.
+type Conn struct {
+	*tls.Conn // Conn is embedded for net/http to see Conn as CloseWriter, HandshakeContext, etc.
 
 	// handshakeOnce drives the wrapper handshake() exactly once; the
 	// outcome is cached in handshakeErr so repeat callers (every Read/Write
@@ -90,7 +93,7 @@ type conn struct {
 	*handshakeStats
 }
 
-func (c *conn) Read(b []byte) (int, error) {
+func (c *Conn) Read(b []byte) (int, error) {
 	if err := c.handshake(); err != nil {
 		return 0, err
 	}
@@ -99,7 +102,7 @@ func (c *conn) Read(b []byte) (int, error) {
 	return size, err
 }
 
-func (c *conn) Write(b []byte) (int, error) {
+func (c *Conn) Write(b []byte) (int, error) {
 	if err := c.handshake(); err != nil {
 		return 0, err
 	}
@@ -115,7 +118,7 @@ func (c *conn) Write(b []byte) (int, error) {
 //
 // Also, the returned struct's unexported ekm closure is unset, so calling
 // ExportKeyingMaterial on it will panic.
-func (c *conn) ConnectionState() origtls.ConnectionState {
+func (c *Conn) ConnectionState() origtls.ConnectionState {
 	cs := c.Conn.ConnectionState()
 	return origtls.ConnectionState{
 		Version:                     cs.Version,
@@ -140,7 +143,7 @@ func (c *conn) ConnectionState() origtls.ConnectionState {
 // outcome. Stats are updated exactly once: a success bumps Successes; a
 // failure bumps the error counters via errorToStats. Subsequent callers see
 // the same cached error (or nil) without re-counting.
-func (c *conn) handshake() error {
+func (c *Conn) handshake() error {
 	c.handshakeOnce.Do(func() {
 		err := c.Conn.Handshake()
 		if err != nil {
@@ -153,7 +156,7 @@ func (c *conn) handshake() error {
 	return c.handshakeErr
 }
 
-func (c *conn) errorToStats(err error) {
+func (c *Conn) errorToStats(err error) {
 	if err != nil {
 		c.Errs.Add(1)
 		if err == io.EOF {

--- a/howhttp/conn_internal_test.go
+++ b/howhttp/conn_internal_test.go
@@ -1,0 +1,42 @@
+package howhttp
+
+import (
+	"expvar"
+	"net"
+	"testing"
+
+	tls "github.com/jmhodges/howsmyssl/tls1262"
+)
+
+// TestConn_HandshakeFailureCountedOnce locks in the contract that a single
+// handshake failure produces exactly one error increment on the stats — no
+// matter how many subsequent Read/Write calls hit the wrapper. Pre-fix,
+// errorToStats was invoked once by handshake() and again by the Read/Write
+// wrapper, inflating the counter for one logical event; the retry path also
+// re-entered Conn.Conn.Read, which re-counted the cached handshake error.
+func TestConn_HandshakeFailureCountedOnce(t *testing.T) {
+	serverPipe, clientPipe := net.Pipe()
+	// Close the peer immediately so the server-side Handshake errors out
+	// reading the ClientHello.
+	clientPipe.Close()
+
+	stats := newHandshakeStats(new(expvar.Map).Init())
+	conn := &Conn{
+		Conn:           tls.Server(serverPipe, &tls.Config{}),
+		handshakeStats: stats,
+	}
+
+	b := make([]byte, 1)
+	for i := range 3 {
+		if _, err := conn.Read(b); err == nil {
+			t.Fatalf("Read #%d: expected error on conn with closed peer, got nil", i)
+		}
+	}
+
+	if got := stats.Errs.Value(); got != 1 {
+		t.Errorf("Errs = %d after 3 Reads on a failed-handshake conn, want 1", got)
+	}
+	if got := stats.Successes.Value(); got != 0 {
+		t.Errorf("Successes = %d, want 0", got)
+	}
+}

--- a/howhttp/httptest/cert.go
+++ b/howhttp/httptest/cert.go
@@ -1,0 +1,52 @@
+package howhttptest
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+// generateLocalhostCert returns a freshly-generated self-signed ECDSA P-256
+// certificate suitable for serving on 127.0.0.1 / ::1, along with the parsed
+// leaf and the private key.
+func generateLocalhostCert() (certDER []byte, leaf *x509.Certificate, key *ecdsa.PrivateKey, err error) {
+	key, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("howhttptest: generating key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("howhttptest: generating serial: %w", err)
+	}
+
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "howhttptest"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err = x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("howhttptest: creating certificate: %w", err)
+	}
+
+	leaf, err = x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("howhttptest: parsing generated certificate: %w", err)
+	}
+	return certDER, leaf, key, nil
+}

--- a/howhttp/httptest/httptest.go
+++ b/howhttp/httptest/httptest.go
@@ -1,0 +1,201 @@
+// Package howhttptest provides utilities for spinning up a [howhttp.Server]
+// backed by a [tls1262.Listen]er for use in tests, in the style of
+// [net/http/httptest].
+//
+// Use [NewServer] to start a server bound to 127.0.0.1 with a freshly
+// generated, self-signed certificate. The returned [*Server] exposes a
+// preconfigured [*http.Client] that trusts the generated certificate, plus
+// builders for [*crypto/tls.Config] and [*tls1262.Config] for tests that need
+// to drive raw TLS connections.
+package howhttptest
+
+import (
+	"context"
+	origtls "crypto/tls"
+	"crypto/x509"
+	"errors"
+	"expvar"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/jmhodges/howsmyssl/howhttp"
+	tls1262 "github.com/jmhodges/howsmyssl/tls1262"
+)
+
+// Server is a TLS HTTP server listening on a random localhost port, serving
+// over a [tls1262.Listen]er wrapped by [howhttp.NewListener] and a
+// [howhttp.Server]. It is the howhttp equivalent of
+// [net/http/httptest.Server].
+//
+// The fields below are populated by [NewServer] and must not be mutated after
+// it returns; they are exposed for inspection.
+type Server struct {
+	// URL is the base URL ("https://127.0.0.1:PORT") clients should target.
+	URL string
+	// Listener is the [howhttp.NewListener]-wrapped tls1262 listener that the
+	// server is accepting on.
+	Listener net.Listener
+	// TLS is the [tls1262.Config] the server is using.
+	TLS *tls1262.Config
+	// Config is the underlying [howhttp.Server].
+	Config *howhttp.Server
+
+	leafCert *x509.Certificate
+	rootCAs  *x509.CertPool
+
+	serveErr chan error
+
+	clientOnce sync.Once
+	client     *http.Client
+}
+
+// NewServer starts and returns a new [Server] serving handler over TLS on a
+// random localhost port. The server generates a fresh self-signed
+// certificate at construction time; tests should obtain a trusting
+// [*http.Client] via [Server.Client].
+//
+// NewServer panics if it cannot bind a listener, generate a certificate, or
+// configure the underlying [howhttp.Server]. The caller must call
+// [Server.Close] when finished.
+func NewServer(handler http.Handler) *Server {
+	certDER, leaf, key, err := generateLocalhostCert()
+	if err != nil {
+		panic(err)
+	}
+
+	rootCAs := x509.NewCertPool()
+	rootCAs.AddCert(leaf)
+
+	tlsConf := &tls1262.Config{
+		Certificates: []tls1262.Certificate{{
+			Certificate: [][]byte{certDER},
+			PrivateKey:  key,
+			Leaf:        leaf,
+		}},
+		NextProtos: []string{"h2", "http/1.1"},
+	}
+
+	nl, err := tls1262.Listen("tcp", "127.0.0.1:0", tlsConf)
+	if err != nil {
+		panic(fmt.Errorf("howhttptest: listen: %w", err))
+	}
+
+	li := howhttp.NewListener(nl, new(expvar.Map).Init())
+
+	hs, err := howhttp.NewServer(li, handler)
+	if err != nil {
+		li.Close()
+		panic(fmt.Errorf("howhttptest: howhttp.NewServer: %w", err))
+	}
+
+	s := &Server{
+		URL:      "https://" + li.Addr().String(),
+		Listener: li,
+		TLS:      tlsConf,
+		Config:   hs,
+		leafCert: leaf,
+		rootCAs:  rootCAs,
+		serveErr: make(chan error, 1),
+	}
+
+	go func() { s.serveErr <- hs.Serve() }()
+
+	return s
+}
+
+// NewUnstartedServer returns a [howhttp.Server] bound to a plain TCP
+// listener at 127.0.0.1 on a random port, with [howhttp.Server.Serve]
+// not yet called. It is intended for tests that exercise the Server
+// lifecycle ([howhttp.Server.Shutdown], [howhttp.Server.Close], etc.)
+// without accepting real client connections — the underlying listener
+// does not terminate TLS, so any connection that reaches Accept will
+// fail at handshake.
+//
+// The caller is responsible for closing the returned server (calling
+// Shutdown or Close, typically via t.Cleanup).
+//
+// NewUnstartedServer panics if it cannot bind a listener or
+// configure the [howhttp.Server].
+func NewUnstartedServer(handler http.Handler) *howhttp.Server {
+	nl, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(fmt.Errorf("howhttptest: net.Listen: %w", err))
+	}
+	li := howhttp.NewListener(nl, new(expvar.Map).Init())
+	hs, err := howhttp.NewServer(li, handler)
+	if err != nil {
+		li.Close()
+		panic(fmt.Errorf("howhttptest: howhttp.NewServer: %w", err))
+	}
+	return hs
+}
+
+// Close shuts the server down, blocking until in-flight requests finish or a
+// short internal deadline expires.
+//
+// Close is a void function so it composes with `defer srv.Close()` and
+// `t.Cleanup(srv.Close)`, but it does not swallow failures: if Shutdown
+// errors (most commonly a context.DeadlineExceeded because something
+// failed to drain) or the Serve goroutine returns a non-ErrServerClosed
+// error, the error is logged so a hung or broken shutdown surfaces in
+// the test output instead of disappearing.
+func (s *Server) Close() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.Config.Shutdown(ctx); err != nil {
+		log.Printf("howhttptest: Server.Close: Shutdown: %v", err)
+	}
+	if err := <-s.serveErr; err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Printf("howhttptest: Server.Close: Serve returned: %v", err)
+	}
+}
+
+// Certificate returns the parsed leaf certificate the server is presenting.
+func (s *Server) Certificate() *x509.Certificate { return s.leafCert }
+
+// RootCAs returns the [*x509.CertPool] containing the server's leaf
+// certificate. The same pool can be assigned to either a [*crypto/tls.Config]
+// or a [*tls1262.Config], since both use the same [crypto/x509] type.
+func (s *Server) RootCAs() *x509.CertPool { return s.rootCAs }
+
+// ClientTLSConfig returns a fresh [*crypto/tls.Config] that trusts the
+// server's certificate. The returned value may be freely mutated by the
+// caller.
+func (s *Server) ClientTLSConfig() *origtls.Config {
+	return &origtls.Config{
+		RootCAs:    s.rootCAs,
+		ServerName: "127.0.0.1",
+		NextProtos: []string{"h2", "http/1.1"},
+	}
+}
+
+// ClientTLS1262Config returns a fresh [*tls1262.Config] that trusts the
+// server's certificate. Useful for tests that need to drive a raw
+// [tls1262.Dial]-style client. The returned value may be freely mutated by
+// the caller.
+func (s *Server) ClientTLS1262Config() *tls1262.Config {
+	return &tls1262.Config{
+		RootCAs:    s.rootCAs,
+		ServerName: "127.0.0.1",
+		NextProtos: []string{"h2", "http/1.1"},
+	}
+}
+
+// Client returns an HTTP client preconfigured to trust the server's
+// certificate and to negotiate HTTP/2 via ALPN when available. The same
+// client instance is returned on subsequent calls.
+func (s *Server) Client() *http.Client {
+	s.clientOnce.Do(func() {
+		s.client = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig:   s.ClientTLSConfig(),
+				ForceAttemptHTTP2: true,
+			},
+		}
+	})
+	return s.client
+}

--- a/howhttp/httptest/httptest_test.go
+++ b/howhttp/httptest/httptest_test.go
@@ -1,0 +1,27 @@
+package howhttptest_test
+
+import (
+	"net/http"
+	"testing"
+
+	howhttptest "github.com/jmhodges/howsmyssl/howhttp/httptest"
+)
+
+func TestServer_CertificateAndRootCAs(t *testing.T) {
+	srv := howhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	if srv.Certificate() == nil {
+		t.Fatal("Certificate() returned nil")
+	}
+	if srv.RootCAs() == nil {
+		t.Fatal("RootCAs() returned nil")
+	}
+	// Both config builders should reference the same pool.
+	if srv.ClientTLSConfig().RootCAs != srv.RootCAs() {
+		t.Error("ClientTLSConfig().RootCAs != RootCAs()")
+	}
+	if srv.ClientTLS1262Config().RootCAs != srv.RootCAs() {
+		t.Error("ClientTLS1262Config().RootCAs != RootCAs()")
+	}
+}

--- a/howhttp/server.go
+++ b/howhttp/server.go
@@ -1,0 +1,460 @@
+package howhttp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	tls1262 "github.com/jmhodges/howsmyssl/tls1262"
+	"golang.org/x/net/http2"
+)
+
+type contextKey struct{ name string }
+
+func (k *contextKey) String() string { return "howhttp context value " + k.name }
+
+// smuggledConnKey is for smuggling our wrapping *Conn's underlying *tls.Conn
+// out to handlers that need to investigate the client's TLS settings.
+var smuggledConnKey = &contextKey{"smuggledConn"}
+
+// SmuggledConn returns the underlying *tls1262.Conn that was attached to the
+// request's context.
+func SmuggledConn(ctx context.Context) (*tls1262.Conn, bool) {
+	tc, ok := ctx.Value(smuggledConnKey).(*tls1262.Conn)
+	return tc, ok
+}
+
+// addTLSConnToContext is suitable for use as http.Server.ConnContext. It pulls
+// the underlying *tls1262.Conn out of a *Conn and stashes it on the context for
+// handlers to retrieve via SmuggledConn.
+//
+// We do this smuggling instead of using http.Hijacker.Hijack to avoid needing
+// to do a bunch of connection management and HTTP response formatting
+// ourselves. We smuggle the whole *tls1262.Conn into the context instead of
+// just its ConnectionState because the handshake may not yet be performed, and
+// we don't want to lock here waiting for the handshake to finish.
+func addTLSConnToContext(ctx context.Context, c net.Conn) context.Context {
+	tc, ok := c.(*Conn)
+	if !ok {
+		log.Printf("howhttp.addTLSConnToContext: unable to convert net.Conn to *howhttp.Conn: %#v\n", c)
+		return ctx
+	}
+	return context.WithValue(ctx, smuggledConnKey, tc.Conn)
+}
+
+// Server is a wrapper around the net/http and x/http2 servers. It exists
+// (instead of using net/http solely) to allow us to use HTTP/2 with our custom
+// TLS library. The net/http library's TLSNextProto and similar hooks only work
+// with types from the crypto/tls package, but we need our own TLS library to
+// be used.
+//
+// Server has to route connections to the correct server based on the TLS ALPN
+// protocol and do some tracking of the connections it creates. It uses
+// http2.ConfigureServer solely to make sure that graceful shutdown works, but
+// doesn't even let the HTTP/1.x server handle the ALPN routing to avoid the
+// crypto/tls type problems (specifically, that TLSNextProto encodes the
+// crypto/tls.Conn type).
+type Server struct {
+	h1        *http.Server
+	h2        *http2.Server
+	routingLi *routingListener
+	realLi    net.Listener
+	h2mu      sync.Mutex
+	h2conns   map[net.Conn]struct{} // for force-close on ctx timeout
+	h2wg      sync.WaitGroup        // waits for ServeConn goroutines to exit
+
+	// startOnce gates the launch of Serve's background goroutines and
+	// races with Shutdown/Close — whichever wins decides whether the
+	// accept loop ever runs. Loser of the race takes a no-goroutines
+	// fast path.
+	startOnce sync.Once
+	started   atomic.Bool
+
+	// serveDone is closed when the h1.Serve goroutine returns. serveErr
+	// is written before the close, so reads after `<-serveDone` are
+	// well-defined. Using a closeable channel (rather than a buffered
+	// error channel with a single slot) lets every Serve caller observe
+	// the result, so repeat / concurrent Serve calls don't block forever
+	// on a drained buffer.
+	serveDone chan struct{}
+	serveErr  error
+
+	acceptDone chan struct{}
+	inShutdown atomic.Bool
+}
+
+// NewServer creates a new Server with the given listener and handler. The
+// listener is expected to be a *Listener, or, at least, a listener created
+// with tls1262.Listen.
+func NewServer(listener net.Listener, handler http.Handler) (*Server, error) {
+	h1 := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       20 * time.Second,
+		WriteTimeout:      20 * time.Second,
+		IdleTimeout:       2 * time.Minute,
+
+		ConnContext: addTLSConnToContext, // Also performed in the http2.ServeConnOpts
+	}
+	h2 := &http2.Server{
+		IdleTimeout: 2 * time.Minute,
+
+		// Server-side keepalive ping (Go 1.24+). Detects half-open conns
+		// through NLBs/proxies that silently drop state.
+		ReadIdleTimeout: 30 * time.Second,
+		PingTimeout:     15 * time.Second,
+	}
+
+	// We call http2.ConfigureServer only to get h1.RegisterOnShutdown's
+	// callback set up with the connections we create. However,
+	err := http2.ConfigureServer(h1, h2)
+	if err != nil {
+		return nil, fmt.Errorf("unable to configure HTTP/2 server: %w", err)
+	}
+
+	rl := newRoutingListener(listener)
+
+	return &Server{
+		h1:         h1,
+		h2:         h2,
+		realLi:     listener,
+		routingLi:  rl,
+		h2conns:    map[net.Conn]struct{}{},
+		serveDone:  make(chan struct{}),
+		acceptDone: make(chan struct{}),
+	}, nil
+}
+
+// Serve starts the HTTP/1.x and HTTP/2 service goroutines and blocks until
+// the server is shut down. Returns http.ErrServerClosed after a successful
+// Shutdown or Close, or the underlying error otherwise.
+//
+// Only the first call starts the goroutines; subsequent concurrent or
+// later calls observe the same outcome (they block until h1.Serve returns
+// and then return the same error). After Shutdown or Close has been called
+// without a preceding Serve, future Serve calls return http.ErrServerClosed
+// immediately.
+func (s *Server) Serve() error {
+	s.startOnce.Do(func() {
+		s.started.Store(true)
+		go func() {
+			s.serveErr = s.h1.Serve(s.routingLi)
+			close(s.serveDone)
+		}()
+		go s.acceptLoop()
+	})
+	if !s.started.Load() {
+		return http.ErrServerClosed
+	}
+	<-s.serveDone
+	if errors.Is(s.serveErr, http.ErrServerClosed) {
+		return http.ErrServerClosed
+	}
+	return s.serveErr
+}
+
+func (s *Server) acceptLoop() {
+	defer close(s.acceptDone)
+	var tempDelay time.Duration // how long to sleep on accept failure
+	for {
+		c, err := s.realLi.Accept()
+		if err != nil {
+			if s.shuttingDown() {
+				// h1.Shutdown / h1.Close will close routingLi and unblock
+				// h1.Serve with http.ErrServerClosed.
+				return
+			}
+			if retriableAcceptError(err) {
+				if tempDelay == 0 {
+					tempDelay = 5 * time.Millisecond
+				} else {
+					tempDelay *= 2
+				}
+				if max := 1 * time.Second; tempDelay > max {
+					tempDelay = max
+				}
+				log.Printf("howhttp: Accept error: %v; retrying in %v", err, tempDelay)
+				time.Sleep(tempDelay)
+				continue
+			}
+			// Non-shutdown, non-retriable error: tear everything down so
+			// Serve returns and realLi doesn't leak. Mark inShutdown so any
+			// in-flight serve() goroutine that finishes its handshake after
+			// this point bails out via the serveH2 guard rather than
+			// registering an h2 conn that nothing will drain. Order: close
+			// realLi first so the socket is released even if routingLi.Close
+			// somehow blocks, then routingLi so h1.Serve returns.
+			log.Printf("howhttp: fatal Accept error: %v", err)
+			s.inShutdown.Store(true)
+			s.realLi.Close()
+			s.routingLi.Close()
+			return
+		}
+		tempDelay = 0
+		ourConn, ok := c.(*Conn)
+		if !ok {
+			log.Printf("Accept: unable to convert net.Conn to *howhttp.Conn: %#v\n", c)
+			c.Close()
+			continue
+		}
+		go s.serve(ourConn)
+	}
+}
+
+func (s *Server) shuttingDown() bool {
+	return s.inShutdown.Load()
+}
+
+// retriableAcceptError reports whether err returned from
+// net.Listener.Accept is a transient condition worth retrying with
+// backoff instead of tearing down the accept loop. It replaces the
+// deprecated net.Error.Temporary().
+//
+// The set mirrors what stdlib's net.OpError.Temporary() returns true
+// for on an "accept" op, minus errnos that can't surface from a
+// blocking Listener.Accept in Go (EAGAIN/EWOULDBLOCK/ETIMEDOUT).
+//
+// Caveats worth knowing if this ever needs revisiting:
+//
+//   - EMFILE/ENFILE (per-process and system-wide FD exhaustion) are
+//     retried here to match stdlib, but Bryan Mills has argued on
+//     golang-nuts that retrying just hides the problem and a
+//     semaphore capping concurrent conns would be better. If we ever
+//     add that cap, EMFILE/ENFILE should probably become fatal.
+//
+//   - ECONNABORTED means the queued connection was reset by the peer
+//     before Accept returned. It's benign — strictly it warrants
+//     "continue immediately, don't sleep" rather than the backoff
+//     path we share with FD exhaustion. We keep one code path for
+//     simplicity; split it if the backoff ever shows up as latency.
+//
+//   - We deliberately don't retry the kernel-transient network
+//     errnos accept(2) lists (ENETDOWN, EPROTO, ENOPROTOOPT,
+//     EHOSTDOWN, ENONET, EHOSTUNREACH, EOPNOTSUPP, ENETUNREACH).
+//     Those indicate real network problems and we'd rather surface
+//     them than spin.
+func retriableAcceptError(err error) bool {
+	return errors.Is(err, syscall.EMFILE) ||
+		errors.Is(err, syscall.ENFILE) ||
+		errors.Is(err, syscall.ECONNABORTED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EINTR)
+}
+
+func (s *Server) serve(c *Conn) {
+	if to := s.tlsHandshakeTimeout(); to > 0 {
+		dl := time.Now().Add(to)
+		c.SetReadDeadline(dl)
+		c.SetWriteDeadline(dl)
+	}
+
+	if err := c.HandshakeContext(context.Background()); err != nil {
+		c.Close()
+		return
+	}
+
+	// 3. Clear deadlines so http.Server / http2.Server set their own.
+	c.SetReadDeadline(time.Time{})
+	c.SetWriteDeadline(time.Time{})
+
+	// 4. Now NegotiatedProtocol is valid; dispatch.
+	switch c.ConnectionState().NegotiatedProtocol {
+	case "h2":
+		s.serveH2(c)
+	default:
+		if err := s.routingLi.deliverToHTTP1Server(c); err != nil {
+			c.Close()
+		}
+	}
+}
+
+func (s *Server) serveH2(c *Conn) {
+	// h2mu serializes us with closeAllH2Conns. Holding it across both the
+	// inShutdown check and h2wg.Add ensures one of two orderings:
+	//   - we run before shutdown: c is in h2conns AND Add(1) has happened
+	//     before any closeAllH2Conns iteration or h2wg.Wait observation.
+	//   - we run after shutdown: we see inShutdown==true and bail.
+	// Without this, a serve() goroutine that finished its handshake just as
+	// Close() began could slip its conn into the map after closeAllH2Conns
+	// scanned, then Add(1) after h2wg.Wait() observed counter==0 — which is
+	// either a hang (Wait re-blocks) or a panic (Add-after-Wait misuse).
+	s.h2mu.Lock()
+	if s.shuttingDown() {
+		s.h2mu.Unlock()
+		c.Close()
+		return
+	}
+	s.h2conns[c] = struct{}{}
+	s.h2wg.Add(1)
+	s.h2mu.Unlock()
+
+	go func() {
+		defer s.h2wg.Done()
+		defer func() {
+			s.h2mu.Lock()
+			delete(s.h2conns, c)
+			s.h2mu.Unlock()
+			c.Close()
+		}()
+		s.h2.ServeConn(c, &http2.ServeConnOpts{
+			Context:    addTLSConnToContext(context.Background(), c),
+			Handler:    s.h1.Handler,
+			BaseConfig: s.h1,
+		})
+	}()
+}
+
+// Shutdown gracefully shuts down the server. It stops accepting new
+// connections, waits for in-flight HTTP/1.x requests to finish, sends
+// GOAWAY on every active HTTP/2 connection (and waits for them to drain),
+// and force-closes any HTTP/2 connections still live when ctx expires.
+//
+// Once Shutdown has been called, the server may not be reused; future
+// calls to Serve return http.ErrServerClosed.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.inShutdown.Store(true)
+	s.preemptServe()
+
+	// 1. Stop accepting new conns. The accept goroutine will close s.rl
+	//    on its way out, which unblocks any in-flight h1.Serve Accept.
+	s.realLi.Close()
+
+	// 2. Wait for accept loop to finish dispatching anything already accepted.
+	<-s.acceptDone
+
+	// 3. h1.Shutdown drains active h1 requests AND, via the
+	//    ConfigureServer-registered hook, sends GOAWAY on every active h2 conn.
+	h1err := s.h1.Shutdown(ctx)
+
+	// 4. Wait for h2.ServeConn goroutines to actually exit (h1.Shutdown
+	//    doesn't track them). If ctx expires first, force-close.
+	done := make(chan struct{})
+	go func() { s.h2wg.Wait(); close(done) }()
+
+	select {
+	case <-done:
+		return h1err
+	case <-ctx.Done():
+		s.closeAllH2Conns()
+		s.h2wg.Wait()
+		return errors.Join(h1err, ctx.Err())
+	}
+}
+
+// Close immediately closes the listener and every tracked connection,
+// regardless of state. For a graceful drain, use Shutdown.
+//
+// Once Close has been called, the server may not be reused; future
+// calls to Serve return http.ErrServerClosed.
+func (s *Server) Close() error {
+	s.inShutdown.Store(true)
+	s.preemptServe()
+	realErr := s.realLi.Close()
+	<-s.acceptDone
+	h1err := s.h1.Close()
+	s.closeAllH2Conns()
+	s.h2wg.Wait()
+	return errors.Join(filterBenignClose(realErr), filterBenignClose(h1err))
+}
+
+// filterBenignClose drops net.ErrClosed since it just means a listener or
+// conn we were going to close was already closed by another path (the most
+// common cases: double-Close, Close after Shutdown, or Close after the
+// accept loop tore the listener down on a fatal Accept error). Callers
+// shouldn't have to special-case that to tell real failures from idempotent
+// teardown.
+func filterBenignClose(err error) error {
+	if errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
+// RegisterOnShutdown registers a function to call on Shutdown. See
+// http.Server.RegisterOnShutdown for details. Callbacks are run via
+// s.h1, which is also where the http2 GOAWAY hook is registered, so user
+// callbacks compose with it correctly.
+func (s *Server) RegisterOnShutdown(f func()) { s.h1.RegisterOnShutdown(f) }
+
+// preemptServe ensures Serve will never start the background goroutines
+// after Shutdown/Close has been entered. If Serve has already run,
+// startOnce is a no-op; if Serve has not yet run, we pre-close
+// acceptDone so the <-s.acceptDone wait in Shutdown/Close doesn't block,
+// and any later Serve sees startOnce done with started==false and
+// returns http.ErrServerClosed.
+func (s *Server) preemptServe() {
+	s.startOnce.Do(func() {
+		close(s.acceptDone)
+	})
+}
+
+func (s *Server) closeAllH2Conns() {
+	s.h2mu.Lock()
+	defer s.h2mu.Unlock()
+	for c := range s.h2conns {
+		c.Close() // h2.ServeConn returns once the conn is closed
+	}
+}
+
+// tlsHandshakeTimeout returns the time limit permitted for the TLS
+// handshake, or zero for unlimited.
+//
+// It returns the minimum of any positive ReadHeaderTimeout,
+// ReadTimeout, or WriteTimeout.
+func (s *Server) tlsHandshakeTimeout() time.Duration {
+	var ret time.Duration
+	for _, v := range [...]time.Duration{
+		s.h1.ReadHeaderTimeout,
+		s.h1.ReadTimeout,
+		s.h1.WriteTimeout,
+	} {
+		if v <= 0 {
+			continue
+		}
+		if ret == 0 || v < ret {
+			ret = v
+		}
+	}
+	return ret
+}
+
+type routingListener struct {
+	net.Listener
+	ch   chan net.Conn
+	done chan struct{}
+	once sync.Once
+}
+
+func newRoutingListener(li net.Listener) *routingListener {
+	return &routingListener{Listener: li, ch: make(chan net.Conn), done: make(chan struct{})}
+}
+
+func (l *routingListener) deliverToHTTP1Server(c net.Conn) error {
+	select {
+	case l.ch <- c:
+		return nil
+	case <-l.done:
+		return net.ErrClosed
+	}
+}
+
+func (l *routingListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.ch:
+		return c, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *routingListener) Close() error {
+	l.once.Do(func() { close(l.done) })
+	return nil
+}

--- a/howhttp/server_internal_test.go
+++ b/howhttp/server_internal_test.go
@@ -1,0 +1,69 @@
+package howhttp
+
+import (
+	"expvar"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	tls "github.com/jmhodges/howsmyssl/tls1262"
+	"golang.org/x/net/http2"
+)
+
+// TestServeH2BailsWhenShuttingDown is a deterministic test for the
+// close-vs-spawn race: a serve() goroutine that finishes its handshake
+// after Close has begun must not insert into h2conns or Add to h2wg.
+// Doing either could deadlock h2wg.Wait or panic on Add-after-Wait.
+func TestServeH2BailsWhenShuttingDown(t *testing.T) {
+	s := &Server{
+		h1:         &http.Server{},
+		h2:         &http2.Server{},
+		h2conns:    map[net.Conn]struct{}{},
+		serveDone:  make(chan struct{}),
+		acceptDone: make(chan struct{}),
+	}
+	s.inShutdown.Store(true)
+
+	serverPipe, clientPipe := net.Pipe()
+	defer clientPipe.Close()
+
+	conn := &Conn{
+		Conn:           tls.Server(serverPipe, &tls.Config{}),
+		handshakeStats: newHandshakeStats(new(expvar.Map).Init()),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.serveH2(conn)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("serveH2 did not return promptly when shuttingDown")
+	}
+
+	s.h2mu.Lock()
+	n := len(s.h2conns)
+	s.h2mu.Unlock()
+	if n != 0 {
+		t.Errorf("h2conns has %d entries, want 0", n)
+	}
+
+	// h2wg.Wait must return immediately — Add(1) must not have been called.
+	wgDone := make(chan struct{})
+	go func() { s.h2wg.Wait(); close(wgDone) }()
+	select {
+	case <-wgDone:
+	case <-time.After(time.Second):
+		t.Fatal("h2wg.Wait blocked — Add(1) was called despite shuttingDown")
+	}
+
+	// The pipe should be closed from the server side; the client read
+	// should see io.ErrClosedPipe.
+	if _, err := clientPipe.Read(make([]byte, 1)); err == nil {
+		t.Error("expected pipe read to error after serveH2 closed the conn")
+	}
+}

--- a/howhttp/server_test.go
+++ b/howhttp/server_test.go
@@ -1,0 +1,298 @@
+package howhttp_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jmhodges/howsmyssl/howhttp"
+	howhttptest "github.com/jmhodges/howsmyssl/howhttp/httptest"
+)
+
+var noopHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+func TestServer_ShutdownBeforeServe(t *testing.T) {
+	hs := howhttptest.NewUnstartedServer(noopHandler)
+	t.Cleanup(func() { _ = hs.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := hs.Shutdown(ctx); err != nil {
+		t.Errorf("Shutdown: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- hs.Serve() }()
+	select {
+	case err := <-done:
+		if !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("Serve after Shutdown returned %v, want http.ErrServerClosed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after Shutdown")
+	}
+}
+
+func TestServer_CloseBeforeServe(t *testing.T) {
+	hs := howhttptest.NewUnstartedServer(noopHandler)
+	t.Cleanup(func() { _ = hs.Close() })
+
+	if err := hs.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- hs.Serve() }()
+	select {
+	case err := <-done:
+		if !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("Serve after Close returned %v, want http.ErrServerClosed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after Close")
+	}
+}
+
+func TestServer_DoubleShutdown(t *testing.T) {
+	hs := howhttptest.NewUnstartedServer(noopHandler)
+	t.Cleanup(func() { _ = hs.Close() })
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	errs := make([]error, 2)
+	for i := range errs {
+		go func(i int) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			errs[i] = hs.Shutdown(ctx)
+		}(i)
+	}
+	doneAll := make(chan struct{})
+	go func() { wg.Wait(); close(doneAll) }()
+	select {
+	case <-doneAll:
+	case <-time.After(3 * time.Second):
+		t.Fatal("concurrent Shutdown calls did not return")
+	}
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("Shutdown #%d: %v", i, err)
+		}
+	}
+}
+
+func TestServer_ServeReturnsErrServerClosed(t *testing.T) {
+	hs := howhttptest.NewUnstartedServer(noopHandler)
+	t.Cleanup(func() { _ = hs.Close() })
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- hs.Serve() }()
+
+	// Give Serve a moment to actually enter the loop. Not strictly
+	// required for correctness (Shutdown handles either order) but makes
+	// the test exercise the post-Serve path rather than the pre-Serve
+	// shortcut.
+	time.Sleep(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := hs.Shutdown(ctx); err != nil {
+		t.Errorf("Shutdown: %v", err)
+	}
+
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("Serve returned %v, want http.ErrServerClosed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after Shutdown")
+	}
+}
+
+func TestServer_RepeatServeReturnsErrServerClosed(t *testing.T) {
+	hs := howhttptest.NewUnstartedServer(noopHandler)
+	t.Cleanup(func() { _ = hs.Close() })
+
+	first := make(chan error, 1)
+	go func() { first <- hs.Serve() }()
+
+	// Give Serve a moment to enter the loop so the test exercises the
+	// post-startOnce path, not the pre-Serve fast path.
+	time.Sleep(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := hs.Shutdown(ctx); err != nil {
+		t.Errorf("Shutdown: %v", err)
+	}
+
+	select {
+	case err := <-first:
+		if !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("first Serve returned %v, want ErrServerClosed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("first Serve did not return after Shutdown")
+	}
+
+	// A second Serve call after the server is done must not block on a
+	// drained buffered channel — it has to return the same outcome.
+	second := make(chan error, 1)
+	go func() { second <- hs.Serve() }()
+	select {
+	case err := <-second:
+		if !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("second Serve returned %v, want ErrServerClosed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("second Serve hung — Serve is not safe to call after the server has stopped")
+	}
+}
+
+func TestServer_ConcurrentServeBothReturn(t *testing.T) {
+	hs := howhttptest.NewUnstartedServer(noopHandler)
+	t.Cleanup(func() { _ = hs.Close() })
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(len(errs))
+	for i := range errs {
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = hs.Serve()
+		}(i)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := hs.Shutdown(ctx); err != nil {
+		t.Errorf("Shutdown: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("concurrent Serves did not both return after Shutdown")
+	}
+
+	for i, err := range errs {
+		if !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("Serve #%d returned %v, want ErrServerClosed", i, err)
+		}
+	}
+}
+
+func TestServer_RegisterOnShutdown(t *testing.T) {
+	hs := howhttptest.NewUnstartedServer(noopHandler)
+	t.Cleanup(func() { _ = hs.Close() })
+
+	fired := make(chan struct{})
+	hs.RegisterOnShutdown(func() { close(fired) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := hs.Shutdown(ctx); err != nil {
+		t.Errorf("Shutdown: %v", err)
+	}
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RegisterOnShutdown callback did not fire")
+	}
+}
+
+// fatalAcceptListener is a net.Listener whose Accept always returns a
+// non-retriable error. It counts Close calls so the test can assert the
+// underlying listener was released.
+type fatalAcceptListener struct {
+	err    error
+	closes atomic.Int32
+}
+
+func (l *fatalAcceptListener) Accept() (net.Conn, error) { return nil, l.err }
+func (l *fatalAcceptListener) Close() error              { l.closes.Add(1); return nil }
+func (l *fatalAcceptListener) Addr() net.Addr            { return &net.TCPAddr{} }
+
+func TestServer_FatalAcceptClosesRealListener(t *testing.T) {
+	li := &fatalAcceptListener{err: errors.New("fatal accept error for test")}
+	hs, err := howhttp.NewServer(li, noopHandler)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- hs.Serve() }()
+
+	select {
+	case <-serveErr:
+		// Don't assert on the error class — the accept loop translates the
+		// fatal error into an http.ErrServerClosed from h1.Serve. What we
+		// care about is that the real listener was closed.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after fatal Accept error")
+	}
+
+	if got := li.closes.Load(); got < 1 {
+		t.Errorf("realLi.Close call count = %d, want >=1", got)
+	}
+}
+
+func TestServer_CloseForcesH2(t *testing.T) {
+	// Handler that blocks until the request context is cancelled — i.e.
+	// until the underlying h2 conn is torn down.
+	handlerEntered := make(chan struct{})
+	srv := howhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case handlerEntered <- struct{}{}:
+		default:
+		}
+		<-r.Context().Done()
+	}))
+
+	// Kick off an h2 request that will hang in the handler.
+	reqDone := make(chan error, 1)
+	go func() {
+		resp, err := srv.Client().Get(srv.URL + "/")
+		if err != nil {
+			reqDone <- err
+			return
+		}
+		_, err = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		reqDone <- err
+	}()
+
+	select {
+	case <-handlerEntered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler never entered")
+	}
+
+	// Now force-close. Should return quickly even though the handler is
+	// still parked.
+	closeStart := time.Now()
+	if err := srv.Config.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+	if elapsed := time.Since(closeStart); elapsed > 2*time.Second {
+		t.Errorf("Close took %v, want under 2s", elapsed)
+	}
+
+	select {
+	case <-reqDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client request did not unblock after Close")
+	}
+}

--- a/howhttp/smoke_test.go
+++ b/howhttp/smoke_test.go
@@ -1,0 +1,122 @@
+package howhttp_test
+
+import (
+	"bufio"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/jmhodges/howsmyssl/howhttp"
+	howhttptest "github.com/jmhodges/howsmyssl/howhttp/httptest"
+	tls1262 "github.com/jmhodges/howsmyssl/tls1262"
+)
+
+func TestServer_HTTP11(t *testing.T) {
+	srv := howhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "hello")
+	}))
+	defer srv.Close()
+
+	tlsConf := srv.ClientTLSConfig()
+	tlsConf.NextProtos = []string{"http/1.1"}
+	c := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsConf},
+	}
+
+	resp, err := c.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("Get: %s", err)
+	}
+	defer resp.Body.Close()
+	if resp.ProtoMajor != 1 {
+		t.Errorf("ProtoMajor = %d, want 1", resp.ProtoMajor)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %s", err)
+	}
+	if string(b) != "hello" {
+		t.Errorf("body = %q, want %q", b, "hello")
+	}
+}
+
+func TestServer_HTTP2(t *testing.T) {
+	srv := howhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "hello")
+	}))
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("Get: %s", err)
+	}
+	defer resp.Body.Close()
+	if resp.ProtoMajor != 2 {
+		t.Errorf("ProtoMajor = %d, want 2 (ALPN should negotiate h2)", resp.ProtoMajor)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %s", err)
+	}
+	if string(b) != "hello" {
+		t.Errorf("body = %q, want %q", b, "hello")
+	}
+}
+
+func TestServer_SmuggledConnReachable(t *testing.T) {
+	srv := howhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := howhttp.SmuggledConn(r.Context()); !ok {
+			http.Error(w, "no smuggled conn", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("Get: %s", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestServer_RawTLS1262Client(t *testing.T) {
+	srv := howhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "raw")
+	}))
+	defer srv.Close()
+
+	conf := srv.ClientTLS1262Config()
+	conf.NextProtos = []string{"http/1.1"}
+
+	addr := strings.TrimPrefix(srv.URL, "https://")
+	c, err := tls1262.Dial("tcp", addr, conf)
+	if err != nil {
+		t.Fatalf("Dial: %s", err)
+	}
+	defer c.Close()
+
+	if _, err := io.WriteString(c, "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"); err != nil {
+		t.Fatalf("WriteString: %s", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(c), nil)
+	if err != nil {
+		t.Fatalf("ReadResponse: %s", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %s", err)
+	}
+	if string(b) != "raw" {
+		t.Errorf("body = %q, want %q", b, "raw")
+	}
+}

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -25,6 +25,7 @@ import (
 
 	"cloud.google.com/go/logging"
 	"github.com/jmhodges/howsmyssl/gzip"
+	"github.com/jmhodges/howsmyssl/howhttp"
 	tls "github.com/jmhodges/howsmyssl/tls1262"
 	"google.golang.org/api/option"
 )
@@ -65,14 +66,6 @@ var (
 	index *template.Template
 )
 
-type contextKey struct{ name string }
-
-func (k *contextKey) String() string { return "howsmyssl context value " + k.name }
-
-// smuggledConnKey is for smuggling our wrapping *conn to the apiHandler that
-// needs its conn.Conn.ConnectionState to investigate the client's TLS settings.
-var smuggledConnKey = &contextKey{"smuggledConn"}
-
 func main() {
 	flag.Parse()
 	t := time.Now()
@@ -102,7 +95,7 @@ func main() {
 		log.Fatalf("unable to listen for the HTTP server on %s: %s", *httpAddr, err)
 	}
 	ns := expvar.NewMap("tls")
-	l := newListener(tlsListener, ns)
+	l := howhttp.NewListener(tlsListener, ns)
 
 	if *acmeURL != "" {
 		if !strings.HasPrefix(*acmeURL, "/") &&
@@ -196,8 +189,10 @@ func main() {
 		}
 	}()
 
-	httpsSrv := &http.Server{Handler: m}
-	configureHTTPSServer(httpsSrv)
+	httpsSrv, err := howhttp.NewServer(l, m)
+	if err != nil {
+		log.Fatalf("unable to create custom TLS HTTPS server: %s", err)
+	}
 
 	httpSrv := &http.Server{
 		Handler:      plaintextMux(redirectHost, requestLogger),
@@ -209,7 +204,7 @@ func main() {
 
 	log.Printf("Booting HTTPS on %s and HTTP on %s", *httpsAddr, *httpAddr)
 	go func() {
-		err := httpsSrv.Serve(l)
+		err := httpsSrv.Serve()
 		if err != nil && err != http.ErrServerClosed {
 			log.Fatalf("https server error: %s", err)
 		}
@@ -242,29 +237,6 @@ func main() {
 	wg.Wait()
 	cancel()
 	gclog.Flush()
-}
-
-func configureHTTPSServer(srv *http.Server) {
-	// If you add HTTP/2 or HTTP/3 support here, be sure that the Connection:
-	// close header is being set properly elsewhere
-	srv.ReadTimeout = 10 * time.Second
-	srv.WriteTimeout = 15 * time.Second
-	srv.ConnContext = func(ctx context.Context, c net.Conn) context.Context {
-		tc, ok := c.(*conn)
-		if !ok {
-			log.Printf("Server.ConnContext: unable to convert net.Conn to *conn: %#v\n", c)
-			return ctx
-		}
-		// We do this smuggling instead of using http.Hijcker.Hijack to avoid
-		// needing to do a bunch of connection management and HTTP response
-		// formatting ourselves. We smuggle the whole *conn into the context
-		// instead of just its ConnectionState because the handshake may not yet
-		// be performed, and I don't want to lock here waiting for the handshake
-		// to finish. It might be fine, but I've not verified there's nothing
-		// that would be delayed by doing so.
-		ctx = context.WithValue(ctx, smuggledConnKey, tc.Conn)
-		return ctx
-	}
 }
 
 // Returns routeHost, redirectHost
@@ -333,15 +305,16 @@ func tlsMux(routeHost, redirectHost, acmeRedirectURL string, staticHandler http.
 	})
 	wrapper := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Strict-Transport-Security", hstsHeaderValue)
-		if r.ProtoMajor == 1 && r.ProtoMinor == 1 {
-			// We always disconnect folks after their request is done to ensure
-			// we don't keep our tls.Conn fork with it's extra large memory
-			// needs (including the `clientHelloMsg`) around for too long. This
-			// also helps prevent any TLS resumptions from happening and
-			// breaking our vuln detection. We do this on all requests to avoid
-			// races.
-			w.Header().Set("Connection", "close")
-		}
+
+		// We always disconnect folks after their request is done to ensure
+		// we don't keep our tls.Conn fork with it's extra large memory
+		// needs (including the `clientHelloMsg`) around for too long. This
+		// also helps prevent any TLS resumptions from happening and
+		// breaking our vuln detection. We do this on all requests to avoid
+		// races. This works on even HTTP/2 because the Go HTTP server will
+		// send a GOAWAY frame if it sees this header in the response.
+		w.Header().Set("Connection", "close")
+
 		gzippedM.ServeHTTP(w, r)
 	})
 	return protoHandler{logHandler{wrapper, requestLogger}, "https"}
@@ -438,10 +411,9 @@ func handleTLSClientInfo(w http.ResponseWriter, r *http.Request, statuses *statu
 	// avoid needing to do a bunch of connection management and HTTP response
 	// formatting ourselves.
 	w = &statWriter{w: w, stats: statuses}
-	c := r.Context().Value(smuggledConnKey)
-	tc, ok := c.(*tls.Conn)
+	tc, ok := howhttp.SmuggledConn(r.Context())
 	if !ok {
-		log.Printf("handleTLSClientInfo: unable to convert smuggledConnKey to *tls.Conn: %#v", c)
+		log.Printf("handleTLSClientInfo: unable to retrieve smuggled *tls.Conn from request context")
 		response500(w, r)
 		return
 	}
@@ -539,6 +511,7 @@ func makeTLSConfig(certPath, keyPath string) *tls.Config {
 	go reloadKeypairForever(kpr, time.NewTicker(1*time.Hour))
 	tlsConf := &tls.Config{
 		GetCertificate:           kpr.GetCertificate,
+		NextProtos:               []string{"h2", "http/1.1"},
 		PreferServerCipherSuites: true,
 		MinVersion:               tls.VersionTLS10,
 		CipherSuites: []uint16{
@@ -628,13 +601,13 @@ func (h logHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if userAgent == "" {
 		userAgent = "nouseragent"
 	}
-	tlsConn, ok := r.Context().Value(smuggledConnKey).(*tls.Conn)
+	tlsConn, ok := howhttp.SmuggledConn(r.Context())
 	tlsVersion := "none"
 	if ok && tlsConn != nil {
 		version := tlsConn.ConnectionState().Version
 		tlsVersion = actualSupportedVersions[version]
 	}
-	h.requestLogger.InfoContext(r.Context(), "request", "host", host, "proto", proto, "requestURL", r.URL, "referrerHeader", referrer, "originHeader", origin, "userAgent", userAgent, "tlsVersion", tlsVersion)
+	h.requestLogger.InfoContext(r.Context(), "request", "host", host, "proto", proto, "requestURL", r.URL, "referrerHeader", referrer, "originHeader", origin, "userAgent", userAgent, "tlsVersion", tlsVersion, "httpVersion", r.Proto)
 	h.inner.ServeHTTP(w, r)
 }
 

--- a/index_test.go
+++ b/index_test.go
@@ -3,14 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
-	origtls "crypto/tls"
 	"encoding/json"
 	"errors"
 	"expvar"
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -20,7 +18,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	tls1262 "github.com/jmhodges/howsmyssl/tls1262"
+	howhttptest "github.com/jmhodges/howsmyssl/howhttp/httptest"
 )
 
 type testWriter struct {
@@ -352,40 +350,8 @@ func TestJSONAPI(t *testing.T) {
 	oa := newOriginAllower(ama, "testhostname", nullLogClient{}, new(expvar.Map).Init(), newTestLogger(t))
 	tm := tlsMux("", "www.howsmyssl.com", "www.howsmyssl.com", staticHandler, webHandleFunc, oa, newTestLogger(t), newTestLogger(t))
 
-	tl, err := tls1262.Listen("tcp", "127.0.0.1:0", serverConf)
-	if err != nil {
-		t.Fatalf("NewListener: %s", err)
-	}
-	li := newListener(tl, new(expvar.Map).Init())
-
-	srv := httptest.NewUnstartedServer(tm)
-	configureHTTPSServer(srv.Config)
-	srv.Listener = li
-	// Intentionally not using StartTLS to avoid stomping on our special listener.
-	srv.Start()
+	srv := howhttptest.NewServer(tm)
 	defer srv.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	defer cancel()
-	c := &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-				DualStack: true,
-			}).DialContext,
-			MaxIdleConns:          100,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-			TLSClientConfig: &origtls.Config{
-				InsecureSkipVerify: true,
-			},
-		},
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return errors.New("no redirects should be seen")
-		},
-	}
 
 	type apiTest struct {
 		path        string
@@ -422,39 +388,121 @@ func TestJSONAPI(t *testing.T) {
 			body:        "foobarParse(" + string(disallowedOriginBody) + ");",
 		},
 	}
-	u := strings.Replace(srv.URL, "http://", "https://", -1)
-	for i, at := range tests {
-		t.Run(fmt.Sprintf("%d-%s", i, at.path), func(t *testing.T) {
-			r, err := http.NewRequest("GET", u+at.path, nil)
-			if err != nil {
-				t.Fatalf("NewRequest: %s", err)
-			}
-			r = r.WithContext(ctx)
-			r.Header.Set("Origin", at.origin)
-			resp, err := c.Do(r)
-			if err != nil {
-				t.Fatalf("Get: %s", err)
-			}
-			b, err := io.ReadAll(resp.Body)
-			defer resp.Body.Close()
-			if err != nil {
-				t.Fatalf("ReadAll: %s", err)
-			}
-			if resp.StatusCode != at.status {
-				t.Errorf("status code, want: %d, got: %d", at.status, resp.StatusCode)
-			}
-			if string(b) != at.body {
-				t.Errorf("body, diff: %s", cmp.Diff(at.body, string(b)))
-				t.Errorf("body, want:\n%#v\ngot:%#v\n", at.body, string(b))
-			}
-			ct := resp.Header.Get("Content-Type")
-			if ct != at.contentType {
-				t.Errorf("Content-Type, want %s, got %s", at.contentType, ct)
-			}
-			if !resp.Close {
-				t.Errorf("want connection to be closed after each request, but was left open")
-			}
-		})
+	run := func(t *testing.T, c *http.Client, wantProtoMajor int, wantConnClose bool) {
+		for i, at := range tests {
+			t.Run(fmt.Sprintf("%d-%s", i, at.path), func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+				defer cancel()
+
+				r, err := http.NewRequestWithContext(ctx, "GET", srv.URL+at.path, nil)
+				if err != nil {
+					t.Fatalf("NewRequest: %s", err)
+				}
+
+				r.Header.Set("Origin", at.origin)
+				resp, err := c.Do(r)
+				if err != nil {
+					t.Fatalf("Get: %s", err)
+				}
+				b, err := io.ReadAll(resp.Body)
+				defer resp.Body.Close()
+				if err != nil {
+					t.Fatalf("ReadAll: %s", err)
+				}
+				if resp.ProtoMajor != wantProtoMajor {
+					t.Errorf("ProtoMajor, want: %d, got: %d (%s)", wantProtoMajor, resp.ProtoMajor, resp.Proto)
+				}
+				if resp.StatusCode != at.status {
+					t.Errorf("status code, want: %d, got: %d", at.status, resp.StatusCode)
+				}
+				if string(b) != at.body {
+					t.Errorf("body, diff: %s", cmp.Diff(at.body, string(b)))
+					t.Errorf("body, want:\n%#v\ngot:%#v\n", at.body, string(b))
+				}
+				ct := resp.Header.Get("Content-Type")
+				if ct != at.contentType {
+					t.Errorf("Content-Type, want %s, got %s", at.contentType, ct)
+				}
+				if wantConnClose && !resp.Close {
+					t.Errorf("want connection to be closed after each request, but was left open")
+				}
+			})
+		}
+	}
+
+	noRedirects := func(req *http.Request, via []*http.Request) error {
+		return errors.New("no redirects should be seen")
+	}
+
+	t.Run("http1.1", func(t *testing.T) {
+		// The per-request Connection: close assertion is only meaningful for
+		// HTTP/1.1; force the ALPN choice so the transport can't pick h2.
+		tlsConf := srv.ClientTLSConfig()
+		tlsConf.NextProtos = []string{"http/1.1"}
+		c := &http.Client{
+			Transport:     &http.Transport{TLSClientConfig: tlsConf},
+			CheckRedirect: noRedirects,
+		}
+		run(t, c, 1, true)
+	})
+
+	t.Run("http2", func(t *testing.T) {
+		tlsConf := srv.ClientTLSConfig()
+		tlsConf.NextProtos = []string{"h2"}
+		c := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig:   tlsConf,
+				ForceAttemptHTTP2: true,
+			},
+			CheckRedirect: noRedirects,
+		}
+		run(t, c, 2, false)
+	})
+}
+
+func TestIndexGoldenPath(t *testing.T) {
+	index = loadIndex()
+
+	stats := newStatusStats(new(expvar.Map).Init())
+	staticHandler := makeStaticHandler("/static", stats)
+	am := &allowMaps{
+		AllowTheseDomains: make(map[string]bool),
+		AllowSubdomainsOn: make(map[string]bool),
+		BlockedDomains:    make(map[string]bool),
+	}
+	ama := &atomic.Pointer[allowMaps]{}
+	ama.Store(am)
+	oa := newOriginAllower(ama, "testhostname", nullLogClient{}, new(expvar.Map).Init(), newTestLogger(t))
+	tm := tlsMux("", "www.howsmyssl.com", "www.howsmyssl.com", staticHandler, handleWeb, oa, newTestLogger(t), newTestLogger(t))
+
+	srv := howhttptest.NewServer(tm)
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	r, err := http.NewRequestWithContext(ctx, "GET", srv.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %s", err)
+	}
+	resp, err := srv.Client().Do(r)
+	if err != nil {
+		t.Fatalf("Get: %s", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status code, want: %d, got: %d", http.StatusOK, resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type, want prefix %q, got %q", "text/html", ct)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %s", err)
+	}
+	if len(b) == 0 {
+		t.Error("response body was empty")
 	}
 }
 

--- a/tls_test.go
+++ b/tls_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/jmhodges/howsmyssl/howhttp"
 	tls "github.com/jmhodges/howsmyssl/tls1262"
 	ztls "github.com/zmap/zcrypto/tls"
 	zx509 "github.com/zmap/zcrypto/x509"
@@ -267,14 +268,14 @@ func connect(t *testing.T, clientConf *tls.Config) *tls.Conn {
 	if err != nil {
 		t.Fatalf("NewListener: %s", err)
 	}
-	li := newListener(tl, new(expvar.Map).Init())
+	li := howhttp.NewListener(tl, new(expvar.Map).Init())
 	// bytesLen is picked to be large enough to trigger the BEAST vuln detection
 	// if the client is vulnerable but small enough to not cause too much time
 	// spent in the tests.
 	bytesLen := 256
 	type connRes struct {
 		recv []byte
-		conn *conn
+		conn *howhttp.Conn
 	}
 	ch := make(chan connRes)
 	errCh := make(chan error)
@@ -288,7 +289,7 @@ func connect(t *testing.T, clientConf *tls.Config) *tls.Conn {
 		io.ReadFull(c, b)
 		c.Close()
 		li.Close()
-		tc := c.(*conn)
+		tc := c.(*howhttp.Conn)
 		ch <- connRes{recv: b, conn: tc}
 	}()
 	var c *tls.Conn
@@ -344,11 +345,11 @@ func connectZtls(t *testing.T, clientConf *ztls.Config) *tls.Conn {
 	if err != nil {
 		t.Fatalf("NewListener: %s", err)
 	}
-	li := newListener(tl, new(expvar.Map).Init())
+	li := howhttp.NewListener(tl, new(expvar.Map).Init())
 	bytesLen := 256
 	type connRes struct {
 		recv []byte
-		conn *conn
+		conn *howhttp.Conn
 	}
 	ch := make(chan connRes)
 	errCh := make(chan error)
@@ -362,7 +363,7 @@ func connectZtls(t *testing.T, clientConf *ztls.Config) *tls.Conn {
 		io.ReadFull(c, b)
 		c.Close()
 		li.Close()
-		tc := c.(*conn)
+		tc := c.(*howhttp.Conn)
 		ch <- connRes{recv: b, conn: tc}
 	}()
 	var c *ztls.Conn


### PR DESCRIPTION
This adds the howhttp package to provide HTTP/2 support to howsmyssl
while continuing to use the local tls1262 fork of crypto/tls.

The stdlib's HTTP/2 wiring (http2.ConfigureServer,
srv.TLSNextProto["h2"]) type-asserts on *crypto/tls.Conn, which the fork
can't satisfy. So, howsmyssl has to take over the routing of requests to
the HTTP/1.x and HTTP/2 servers.

The howhttp package provides a new Server type that can serve both
HTTP/1.x and HTTP/2 on the same tls1262 listener.

howhttp.NewServer(li, handler) is how to create one. A howhttp.Server
owns both a HTTP/1.1 *http.Server and a HTTP/2 *http2.Server. A
routingListener accepts connections, runs the TLS handshake in a
goroutine, and dispatches based on ConnectionState().NegotiatedProtocol.
If the NegotiatedProtocol is "h2", we send it to http2.Server.ServeConn
on our wrapped *howhttp.Conn directly. Otherwise, the connection is
forwarded over a channel to a fake listener that h1.Serve is listening
on.

The howhttp.Server has had a good deal of resilience work applied to do
it to keep it as capable as the net/http.Server. The shutdown story had
a lot of back and forth, but is fairly well-tested now; both for the
graceful and immediate shutdown cases.

howhttp.Listener (previously the top-level listener/newListener) wraps a
tls1262 listener and tracks handshake-stats expvars.

howhttp.SmuggledConn(ctx) replaces the package-private smuggledConnKey
work in howsmyssl.go with a nice type-safe API. This is how the
howsmyssl HTTP handlers access the underlying *tls1262.Conn to read the
client's TLS state and report on it.

We also get a new howhttp/httptest subpackage that mirrors
net/http/httptest so tests can spin up a custom TLS server instead of
wiring the listener inline. And the server makes it easy for clients to
rig up the TLS configs they need.

The rest of howsmyssl changed mostly in the tests. They pick up the use
of howhttp/httptest and also test that the detection code works over
both HTTP/1.1 and HTTP/2.
