### PR TITLE
make navbar text higher contrast for a11y reasons

### DIFF
--- a/static/about.html
+++ b/static/about.html
@@ -26,6 +26,8 @@
 
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
+    <link rel="stylesheet" href="/s/css/site.css">
+
     <style type="text/css">
      body {
          padding-top: 60px;

--- a/static/api.html
+++ b/static/api.html
@@ -25,7 +25,9 @@
         crossorigin="anonymous"></script>
     
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-    
+
+    <link rel="stylesheet" href="/s/css/site.css">
+
     <style type="text/css">
      body {
          padding-top: 60px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,6 +26,8 @@
 
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
+    <link rel="stylesheet" href="/s/css/site.css">
+
     <style type="text/css">
      body {
          padding-top: 60px;


### PR DESCRIPTION
The home, About, and API pages each embedded a Bootstrap 3 navbar
override to bump text contrast to WCAG AAA (7:1): #595959 on #f8f8f8
(~7.04:1) for the brand and inactive links, #333 on #f8f8f8 (~12.63:1)
for hover/focus, and #333 on #e7e7e7 (~10.36:1) for the active link.
Bootstrap's defaults (#777 on #f8f8f8, ~4.48:1) fail even WCAG AA.

We pull those overrides into a new site.css file that we may consolidate
more of the site's custom styles into over time.
