### PR TITLE
allow tests to override client signature_algorithms

### DIFF
--- a/tls1262/common.go
+++ b/tls1262/common.go
@@ -823,6 +823,23 @@ type Config struct {
 	// GODEBUG=tlsmlkem=0 or the GODEBUG=tlssecpmlkem=0 environment variable.
 	CurvePreferences []CurveID
 
+	// Added for howsmyssl's use.
+	//
+	// SignatureAlgorithms, if non-nil, overrides the contents of the
+	// signature_algorithms extension (13) the client sends in its ClientHello.
+	// The list is written verbatim — no filtering by TLS version or FIPS mode
+	// — so callers can exercise GREASE values, draft codepoints, and
+	// otherwise-disabled schemes. Setting this on a server Config has no
+	// effect.
+	SignatureAlgorithms []SignatureScheme
+
+	// SignatureAlgorithmsCert, if non-nil, overrides the contents of the
+	// signature_algorithms_cert extension (50) the client sends in its
+	// ClientHello. As with SignatureAlgorithms, the list is written verbatim.
+	// Note that signature_algorithms_cert is only emitted on the wire for TLS
+	// 1.3 ClientHellos.
+	SignatureAlgorithmsCert []SignatureScheme
+
 	// DynamicRecordSizingDisabled disables adaptive sizing of TLS records.
 	// When true, the largest possible TLS record size is always used. When
 	// false, the size of TLS records may be adjusted in an attempt to

--- a/tls1262/handshake_client.go
+++ b/tls1262/handshake_client.go
@@ -119,8 +119,16 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCli
 	}
 
 	if maxVersion >= VersionTLS12 {
-		hello.supportedSignatureAlgorithms = supportedSignatureAlgorithms(minVersion)
-		hello.supportedSignatureAlgorithmsCert = supportedSignatureAlgorithmsCert()
+		if config.SignatureAlgorithms != nil {
+			hello.supportedSignatureAlgorithms = slices.Clone(config.SignatureAlgorithms)
+		} else {
+			hello.supportedSignatureAlgorithms = supportedSignatureAlgorithms(minVersion)
+		}
+		if config.SignatureAlgorithmsCert != nil {
+			hello.supportedSignatureAlgorithmsCert = slices.Clone(config.SignatureAlgorithmsCert)
+		} else {
+			hello.supportedSignatureAlgorithmsCert = supportedSignatureAlgorithmsCert()
+		}
 	}
 
 	var keyShareKeys *keySharePrivateKeys

--- a/tls_test.go
+++ b/tls_test.go
@@ -288,6 +288,120 @@ func TestGivenSignatureAlgorithms(t *testing.T) {
 			t.Errorf("GivenSignatureAlgorithmsCert: want empty, got %v", ci.GivenSignatureAlgorithmsCert)
 		}
 	})
+
+	// The development cert is RSA-2048 with a SHA-256 issuer signature. Each
+	// override below pins a TLS version explicitly so the cipher suite path is
+	// predictable, and includes at least one signature scheme the dev cert can
+	// be signed under so the handshake completes.
+	t.Run("CustomListEchoed", func(t *testing.T) {
+		clientConf := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			MaxVersion: tls.VersionTLS12,
+			SignatureAlgorithms: []tls.SignatureScheme{
+				tls.PKCS1WithSHA256,
+				tls.PSSWithSHA384,
+			},
+		}
+		c := connect(t, clientConf)
+		ci := pullClientInfo(c)
+		t.Logf("%#v", ci)
+
+		want := []string{"rsa_pkcs1_sha256", "rsa_pss_rsae_sha384"}
+		if !cmp.Equal(want, ci.GivenSignatureAlgorithms) {
+			t.Errorf("GivenSignatureAlgorithms: want %v, got %v", want, ci.GivenSignatureAlgorithms)
+		}
+	})
+
+	t.Run("GREASERenders", func(t *testing.T) {
+		clientConf := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			MaxVersion: tls.VersionTLS12,
+			SignatureAlgorithms: []tls.SignatureScheme{
+				tls.SignatureScheme(0x0a0a),
+				tls.PKCS1WithSHA256,
+				tls.SignatureScheme(0x1a1a),
+			},
+		}
+		c := connect(t, clientConf)
+		ci := pullClientInfo(c)
+		t.Logf("%#v", ci)
+
+		want := []string{"GREASE_0A", "rsa_pkcs1_sha256", "GREASE_1A"}
+		if !cmp.Equal(want, ci.GivenSignatureAlgorithms) {
+			t.Errorf("GivenSignatureAlgorithms: want %v, got %v", want, ci.GivenSignatureAlgorithms)
+		}
+	})
+
+	t.Run("MLDSARenders", func(t *testing.T) {
+		clientConf := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			MaxVersion: tls.VersionTLS12,
+			SignatureAlgorithms: []tls.SignatureScheme{
+				tls.SignatureScheme(0x0904),
+				tls.SignatureScheme(0x0905),
+				tls.SignatureScheme(0x0906),
+				tls.PKCS1WithSHA256,
+			},
+		}
+		c := connect(t, clientConf)
+		ci := pullClientInfo(c)
+		t.Logf("%#v", ci)
+
+		want := []string{"mldsa44", "mldsa65", "mldsa87", "rsa_pkcs1_sha256"}
+		if !cmp.Equal(want, ci.GivenSignatureAlgorithms) {
+			t.Errorf("GivenSignatureAlgorithms: want %v, got %v", want, ci.GivenSignatureAlgorithms)
+		}
+	})
+
+	t.Run("UnknownFallback", func(t *testing.T) {
+		clientConf := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			MaxVersion: tls.VersionTLS12,
+			SignatureAlgorithms: []tls.SignatureScheme{
+				tls.SignatureScheme(0x0710),
+				tls.PKCS1WithSHA256,
+			},
+		}
+		c := connect(t, clientConf)
+		ci := pullClientInfo(c)
+		t.Logf("%#v", ci)
+
+		want := []string{"Unknown signature scheme: 0x0710", "rsa_pkcs1_sha256"}
+		if !cmp.Equal(want, ci.GivenSignatureAlgorithms) {
+			t.Errorf("GivenSignatureAlgorithms: want %v, got %v", want, ci.GivenSignatureAlgorithms)
+		}
+	})
+
+	t.Run("CertExtensionEchoed", func(t *testing.T) {
+		// signature_algorithms_cert (ext 50) only goes on the wire for TLS 1.3
+		// ClientHellos. The server doesn't reject based on the cert list, so we
+		// can stuff arbitrary codepoints into SignatureAlgorithmsCert. The
+		// SignatureAlgorithms list still needs an entry the server's RSA cert
+		// can sign under in TLS 1.3, which is PSSWithSHA256.
+		clientConf := &tls.Config{
+			MinVersion: tls.VersionTLS13,
+			MaxVersion: tls.VersionTLS13,
+			SignatureAlgorithms: []tls.SignatureScheme{
+				tls.PSSWithSHA256,
+			},
+			SignatureAlgorithmsCert: []tls.SignatureScheme{
+				tls.SignatureScheme(0x0808),
+				tls.PKCS1WithSHA256,
+			},
+		}
+		c := connect(t, clientConf)
+		ci := pullClientInfo(c)
+		t.Logf("%#v", ci)
+
+		wantSig := []string{"rsa_pss_rsae_sha256"}
+		if !cmp.Equal(wantSig, ci.GivenSignatureAlgorithms) {
+			t.Errorf("GivenSignatureAlgorithms: want %v, got %v", wantSig, ci.GivenSignatureAlgorithms)
+		}
+		wantCert := []string{"ed448", "rsa_pkcs1_sha256"}
+		if !cmp.Equal(wantCert, ci.GivenSignatureAlgorithmsCert) {
+			t.Errorf("GivenSignatureAlgorithmsCert: want %v, got %v", wantCert, ci.GivenSignatureAlgorithmsCert)
+		}
+	})
 }
 
 var serverConf *tls.Config


### PR DESCRIPTION
## Summary

- Add `Config.SignatureAlgorithms` and `Config.SignatureAlgorithmsCert` to the `tls1262` fork. When non-nil, they replace the default lists for ClientHello extensions 13 and 50 verbatim — no version, FIPS, or SHA-1 filtering — so tests can advertise GREASE values, draft codepoints, and otherwise-disabled schemes.
- Extend `TestGivenSignatureAlgorithms` with five new subtests (`CustomListEchoed`, `GREASERenders`, `MLDSARenders`, `UnknownFallback`, `CertExtensionEchoed`) that exercise the rendering paths added in #1022 directly, instead of relying on whatever the stdlib client happens to send.

## Why

Before this change, the existing `TestGivenSignatureAlgorithms` cases could only assert that *some* default-ish scheme showed up in `GivenSignatureAlgorithms` and that TLS 1.0 produced an empty-but-non-nil slice. There was no way to drive specific codepoints through the renderer: the upstream client always sent the filtered defaults, and zcrypto's `Config.SignatureAndHashes` only affects server-side acceptance, not the ClientHello wire bytes. The override field gives us per-connection control without any global state (so subtests can be parallel), and `_cert` coverage that ztls can't provide because zcrypto/tls has no TLS 1.3 path for extension 50.

## Notes for reviewers

- The override is intentionally not version-filtered. That's the whole point — we need to send things like `0x0a0a` and `0x0710` that the production path strips.
- Each TLS 1.2 subtest includes `PKCS1WithSHA256`, and the TLS 1.3 subtest includes `PSSWithSHA256`, so the dev RSA-2048 cert can sign and the handshake actually completes.
- Setting `SignatureAlgorithms` on a server `Config` has no effect; the doc comments call this out.

## Test plan

- [x] `go test ./...` passes locally.
- [x] `TestGivenSignatureAlgorithms` and all 7 subtests pass.
- [x] `go vet ./...` clean (pre-existing diagnostics in unrelated files are unchanged).