### PR TITLE
quiet expected close errors in errorToStats

### DIFF
--- a/howhttp/conn.go
+++ b/howhttp/conn.go
@@ -10,6 +10,8 @@ import (
 	"log"
 	"net"
 	"sync"
+	"sync/atomic"
+	"syscall"
 
 	origtls "crypto/tls"
 
@@ -28,22 +30,26 @@ type Listener struct {
 }
 
 type handshakeStats struct {
-	Successes       *expvar.Int
-	Errs            *expvar.Int
-	ReadTimeouts    *expvar.Int
-	WriteTimeouts   *expvar.Int
-	UnknownTimeouts *expvar.Int
-	EOFs            *expvar.Int
+	Successes         *expvar.Int
+	Errs              *expvar.Int
+	ReadTimeouts      *expvar.Int
+	WriteTimeouts     *expvar.Int
+	UnknownTimeouts   *expvar.Int
+	EOFs              *expvar.Int
+	IntentionalCloses *expvar.Int
+	PeerResets        *expvar.Int
 }
 
 func newHandshakeStats(ns *expvar.Map) *handshakeStats {
 	s := &handshakeStats{
-		Successes:       &expvar.Int{},
-		Errs:            &expvar.Int{},
-		ReadTimeouts:    &expvar.Int{},
-		WriteTimeouts:   &expvar.Int{},
-		UnknownTimeouts: &expvar.Int{},
-		EOFs:            &expvar.Int{},
+		Successes:         &expvar.Int{},
+		Errs:              &expvar.Int{},
+		ReadTimeouts:      &expvar.Int{},
+		WriteTimeouts:     &expvar.Int{},
+		UnknownTimeouts:   &expvar.Int{},
+		EOFs:              &expvar.Int{},
+		IntentionalCloses: &expvar.Int{},
+		PeerResets:        &expvar.Int{},
 	}
 	ns.Set("successes", s.Successes)
 	ns.Set("errors", s.Errs)
@@ -51,6 +57,8 @@ func newHandshakeStats(ns *expvar.Map) *handshakeStats {
 	ns.Set("write_timeouts", s.WriteTimeouts)
 	ns.Set("unknown_timeouts", s.UnknownTimeouts)
 	ns.Set("eofs", s.EOFs)
+	ns.Set("intentional_closes", s.IntentionalCloses)
+	ns.Set("peer_resets", s.PeerResets)
 	return s
 }
 
@@ -90,6 +98,13 @@ type Conn struct {
 	handshakeOnce sync.Once
 	handshakeErr  error
 
+	// draining is set by our Close before delegating to the embedded
+	// tls.Conn.Close. It tells errorToStats that any in-flight Read/Write
+	// returning net.ErrClosed is the normal teardown signal — the frame
+	// reader observing the close we just performed — not an anomaly worth
+	// logging. See errorToStats for the consumer side.
+	draining atomic.Bool
+
 	*handshakeStats
 }
 
@@ -109,6 +124,24 @@ func (c *Conn) Write(b []byte) (int, error) {
 	size, err := c.Conn.Write(b)
 	c.errorToStats(err)
 	return size, err
+}
+
+// Close marks the conn as draining and then delegates to the embedded
+// tls.Conn.Close.
+//
+// Setting draining before the underlying close happens-before any
+// concurrent in-flight Read/Write that subsequently returns net.ErrClosed,
+// so errorToStats can recognize that error as the expected teardown
+// signal rather than logging it as anomalous. Every server-initiated
+// close path in this package routes through here: serve()'s
+// handshake-failure cleanup, serveH2's deferred close after
+// h2.ServeConn returns (idle timeout, peer GOAWAY, MaxConcurrentStreams
+// drain, etc.), closeAllH2Conns during force-shutdown, h1.Server's
+// per-conn close, and the http2 GOAWAY hook registered on h1 by
+// http2.ConfigureServer.
+func (c *Conn) Close() error {
+	c.draining.Store(true)
+	return c.Conn.Close()
 }
 
 // ConnectionState is here for the net/http library to set the `Request.TLS`
@@ -157,22 +190,43 @@ func (c *Conn) handshake() error {
 }
 
 func (c *Conn) errorToStats(err error) {
-	if err != nil {
-		c.Errs.Add(1)
-		if err == io.EOF {
-			c.EOFs.Add(1)
-		} else if opErr, ok := err.(*net.OpError); ok && opErr.Timeout() {
-			switch opErr.Op {
-			case "read":
-				c.ReadTimeouts.Add(1)
-			case "write":
-				c.WriteTimeouts.Add(1)
-			default:
-				log.Printf("unknown timeout type: %s", opErr.Op)
-				c.UnknownTimeouts.Add(1)
-			}
-		} else {
-			log.Printf("unknown tls error: %s", err)
-		}
+	if err == nil {
+		return
 	}
+	c.Errs.Add(1)
+	if err == io.EOF {
+		c.EOFs.Add(1)
+		return
+	}
+	if opErr, ok := err.(*net.OpError); ok && opErr.Timeout() {
+		switch opErr.Op {
+		case "read":
+			c.ReadTimeouts.Add(1)
+		case "write":
+			c.WriteTimeouts.Add(1)
+		default:
+			log.Printf("unknown timeout type: %s", opErr.Op)
+			c.UnknownTimeouts.Add(1)
+		}
+		return
+	}
+	// Our Close ran (graceful shutdown, force-close, h2 idle drain,
+	// h1 per-conn teardown, ...); the in-flight Read/Write observed it
+	// as net.ErrClosed. Expected lifecycle, not an anomaly. We require
+	// draining to be set so that any net.ErrClosed coming from a path
+	// that bypasses our wrapper Close still surfaces as unknown — those
+	// are the ones worth investigating.
+	if c.draining.Load() && errors.Is(err, net.ErrClosed) {
+		c.IntentionalCloses.Add(1)
+		return
+	}
+	// Peer-initiated abrupt close. TCP LBs in front of us routinely RST
+	// conns during idle eviction; clients hang up mid-request. Common
+	// and benign on a public TLS endpoint — watch the rate via expvar
+	// rather than the log.
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+		c.PeerResets.Add(1)
+		return
+	}
+	log.Printf("unknown tls error: %s", err)
 }

--- a/howhttp/conn_internal_test.go
+++ b/howhttp/conn_internal_test.go
@@ -3,6 +3,8 @@ package howhttp
 import (
 	"expvar"
 	"net"
+	"os"
+	"syscall"
 	"testing"
 
 	tls "github.com/jmhodges/howsmyssl/tls1262"
@@ -38,5 +40,128 @@ func TestConn_HandshakeFailureCountedOnce(t *testing.T) {
 	}
 	if got := stats.Successes.Value(); got != 0 {
 		t.Errorf("Successes = %d, want 0", got)
+	}
+}
+
+// TestConn_CloseMarksDraining confirms our Close override sets the
+// draining flag before delegating to the embedded tls.Conn.Close. The
+// flag is what lets errorToStats recognize a concurrent in-flight
+// Read/Write's resulting net.ErrClosed as the expected teardown signal
+// instead of logging it as anomalous.
+func TestConn_CloseMarksDraining(t *testing.T) {
+	serverPipe, clientPipe := net.Pipe()
+	defer clientPipe.Close()
+
+	conn := &Conn{
+		Conn:           tls.Server(serverPipe, &tls.Config{}),
+		handshakeStats: newHandshakeStats(new(expvar.Map).Init()),
+	}
+	if conn.draining.Load() {
+		t.Fatal("draining set before Close")
+	}
+	_ = conn.Close()
+	if !conn.draining.Load() {
+		t.Fatal("draining not set after Close")
+	}
+}
+
+// TestConn_ErrorToStats_IntentionalClose covers the post-Close
+// classification: a net.ErrClosed observed on a draining conn is the
+// frame reader (or a Write loop) noticing the close we performed. It
+// bumps IntentionalCloses, still counts in Errs as a total, and must
+// not fall through to the "unknown tls error" log line.
+func TestConn_ErrorToStats_IntentionalClose(t *testing.T) {
+	stats := newHandshakeStats(new(expvar.Map).Init())
+	conn := &Conn{handshakeStats: stats}
+	conn.draining.Store(true)
+
+	conn.errorToStats(net.ErrClosed)
+
+	if got := stats.IntentionalCloses.Value(); got != 1 {
+		t.Errorf("IntentionalCloses = %d, want 1", got)
+	}
+	if got := stats.Errs.Value(); got != 1 {
+		t.Errorf("Errs = %d, want 1", got)
+	}
+	if got := stats.PeerResets.Value(); got != 0 {
+		t.Errorf("PeerResets = %d, want 0", got)
+	}
+}
+
+// TestConn_ErrorToStats_NetErrClosedNotDraining confirms we don't
+// quietly bucket a net.ErrClosed that arrived without our Close having
+// run. Such an error means some path bypassed our wrapper Close, which
+// is worth investigating, so it must still surface as "unknown tls
+// error" rather than being absorbed by IntentionalCloses.
+func TestConn_ErrorToStats_NetErrClosedNotDraining(t *testing.T) {
+	stats := newHandshakeStats(new(expvar.Map).Init())
+	conn := &Conn{handshakeStats: stats}
+
+	conn.errorToStats(net.ErrClosed)
+
+	if got := stats.IntentionalCloses.Value(); got != 0 {
+		t.Errorf("IntentionalCloses = %d, want 0 (draining unset)", got)
+	}
+	if got := stats.Errs.Value(); got != 1 {
+		t.Errorf("Errs = %d, want 1", got)
+	}
+}
+
+// TestConn_ErrorToStats_TimeoutBeatsDraining locks in cascade ordering:
+// a deadline that fires on the underlying net.Conn surfaces as a
+// *net.OpError whose Timeout() is true, and that classification must
+// win even if Close has already flipped the draining flag. Otherwise a
+// concurrent Close racing a deadline would silently re-bucket real
+// timeouts as IntentionalCloses and we'd lose visibility into them.
+func TestConn_ErrorToStats_TimeoutBeatsDraining(t *testing.T) {
+	stats := newHandshakeStats(new(expvar.Map).Init())
+	conn := &Conn{handshakeStats: stats}
+	conn.draining.Store(true)
+
+	// Shape matches what tls.Conn.Read returns when the underlying
+	// net.Conn's read deadline fires: *net.OpError wrapping a
+	// deadline-exceeded error whose Timeout() returns true.
+	conn.errorToStats(&net.OpError{Op: "read", Err: os.ErrDeadlineExceeded})
+
+	if got := stats.ReadTimeouts.Value(); got != 1 {
+		t.Errorf("ReadTimeouts = %d, want 1", got)
+	}
+	if got := stats.IntentionalCloses.Value(); got != 0 {
+		t.Errorf("IntentionalCloses = %d, want 0 (timeout must win over draining)", got)
+	}
+	if got := stats.Errs.Value(); got != 1 {
+		t.Errorf("Errs = %d, want 1", got)
+	}
+}
+
+// TestConn_ErrorToStats_PeerReset covers ECONNRESET and EPIPE — the
+// errors that show up when the peer (most often a TCP LB doing idle
+// eviction, or a client hanging up mid-request) tears the conn down
+// abruptly. They're benign on a public TLS endpoint; we count them so
+// the rate is visible but don't log each one.
+func TestConn_ErrorToStats_PeerReset(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"ECONNRESET", &net.OpError{Op: "read", Err: syscall.ECONNRESET}},
+		{"EPIPE", &net.OpError{Op: "write", Err: syscall.EPIPE}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stats := newHandshakeStats(new(expvar.Map).Init())
+			conn := &Conn{handshakeStats: stats}
+
+			conn.errorToStats(tc.err)
+
+			if got := stats.PeerResets.Value(); got != 1 {
+				t.Errorf("PeerResets = %d, want 1", got)
+			}
+			if got := stats.Errs.Value(); got != 1 {
+				t.Errorf("Errs = %d, want 1", got)
+			}
+			if got := stats.IntentionalCloses.Value(); got != 0 {
+				t.Errorf("IntentionalCloses = %d, want 0", got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The howsmyssl.go handler wrapper sets `Connection: close` on every response, which tells x/net/http2 to queue a GOAWAY after the response and then close the conn. That close, by design, is what the h2 frame reader observes to learn the conn is gone. The frame reader is parked in c.Read() until the close lands; whoever closes the underlying socket first (us, after h2.ServeConn returns; the peer/LB, via RST or FIN) determines what error pops out.

Before this change errorToStats logged every one of those as "unknown tls error" — because the classification covered io.EOF and *net.OpError timeouts but nothing else, and these errors are net.ErrClosed (we closed) or syscall.ECONNRESET / syscall.EPIPE (peer closed abruptly). With HTTP/2 enabled in #1013 and `Connection: close` forcing a GOAWAY per request, we get one of these errors per HTTP/2 conn termination, plus the steady drip from the GCP TCP LB recycling idle conns and health-checking the backend. The log line was firing constantly while describing every event as anomalous.

To fix the classification:

  - Override Conn.Close to set a draining atomic.Bool before delegating to the embedded tls.Conn.Close. Every server-initiated close in howhttp routes through here (serve()'s handshake-failure cleanup, serveH2's deferred close, closeAllH2Conns, the http2 GOAWAY hook on h1, h1.Server's per-conn teardown), so the flag reliably happens-before the in-flight Read/Write returns net.ErrClosed.

  - In errorToStats, recognize `draining && errors.Is(err, net.ErrClosed)` as the expected teardown and bump a new `intentional_closes` expvar instead of logging. We require draining to be set so a net.ErrClosed coming from a path that bypassed our wrapper Close still surfaces as unknown — those are the ones worth investigating.

  - Also recognize errors.Is(err, syscall.ECONNRESET) and errors.Is(err, syscall.EPIPE) as peer-initiated abrupt close. These have no "we did it" hook (the peer hung up without our involvement), so error-type classification is the only signal. They bump a new `peer_resets` expvar.

The cascade in errorToStats is now `EOF → timeout → draining+ErrClosed → ECONNRESET/EPIPE → unknown`. Timeout is intentionally checked before the draining branch: a deadline that fires on the underlying net.Conn surfaces as *net.OpError with Timeout()==true, and we want it bucketed into ReadTimeouts/WriteTimeouts even if a concurrent Close has already flipped draining. Otherwise a Close racing a deadline would silently re-bucket a real timeout as IntentionalCloses and we'd lose visibility. TestConn_ErrorToStats_TimeoutBeatsDraining pins that ordering.

After this lands, `unknown tls error` should actually mean unknown. The handshake.errors expvar still totals every error (so existing dashboards are unaffected); the new intentional_closes and peer_resets sub-counters let you decompose where the volume is coming from.