### PR TITLE
dated downrank of TLS 1.2 and non-PQ key agreement

### DIFF
--- a/client_info.go
+++ b/client_info.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	tls "github.com/jmhodges/howsmyssl/tls1262"
 )
@@ -15,11 +16,21 @@ const (
 	bad        rating = "Bad"
 )
 
+// Rating cutovers. 10:00 America/Los_Angeles on the given dates, encoded
+// as UTC instants so we don't depend on time/tzdata. June 14 falls in
+// PDT (UTC-7); December 14 falls in PST (UTC-8).
+var (
+	tls12ImprovableCutover = time.Date(2026, 6, 14, 17, 0, 0, 0, time.UTC)
+	tls12BadCutover        = time.Date(2026, 12, 14, 18, 0, 0, 0, time.UTC)
+	noPQImprovableCutover  = time.Date(2026, 6, 14, 17, 0, 0, 0, time.UTC)
+	noPQBadCutover         = time.Date(2026, 12, 14, 18, 0, 0, 0, time.UTC)
+)
+
 type clientInfo struct {
 	GivenCipherSuites              []string            `json:"given_cipher_suites"`
 	GivenNamedGroups               []string            `json:"given_named_groups"`
 	GivenSignatureAlgorithms       []string            `json:"given_signature_algorithms"`
-	PostQuantumKeyAgreement        bool                `json:"post_quantum_key_agreement"`           // neutral (temporarily)
+	PostQuantumKeyAgreement        bool                `json:"post_quantum_key_agreement"`
 	EphemeralKeysSupported         bool                `json:"ephemeral_keys_supported"`             // good if true
 	SessionTicketsSupported        bool                `json:"session_ticket_supported"`             // good if true
 	TLSCompressionSupported        bool                `json:"tls_compression_supported"`            // bad if true
@@ -29,6 +40,10 @@ type clientInfo struct {
 	InsecureCipherSuites           map[string][]string `json:"insecure_cipher_suites"`
 	TLSVersion                     string              `json:"tls_version"`
 	Rating                         rating              `json:"rating"`
+	TLS12ImprovableCutoverPassed   bool                `json:"-"`
+	TLS12BadCutoverPassed          bool                `json:"-"`
+	NoPQImprovableCutoverPassed    bool                `json:"-"`
+	NoPQBadCutoverPassed           bool                `json:"-"`
 }
 
 const (
@@ -70,7 +85,7 @@ var actualSupportedVersions = map[uint16]string{
 	versionTLS13Draft33: "TLS 1.3",
 }
 
-func pullClientInfo(c *tls.Conn) *clientInfo {
+func pullClientInfo(c *tls.Conn, now time.Time) *clientInfo {
 	d := &clientInfo{InsecureCipherSuites: make(map[string][]string)}
 
 	st := c.ConnectionState()
@@ -160,9 +175,17 @@ func pullClientInfo(c *tls.Conn) *clientInfo {
 		d.TLSVersion = "an unknown version of SSL/TLS"
 	}
 
+	d.TLS12ImprovableCutoverPassed = !now.Before(tls12ImprovableCutover)
+	d.TLS12BadCutoverPassed = !now.Before(tls12BadCutover)
+	d.NoPQImprovableCutoverPassed = !now.Before(noPQImprovableCutover)
+	d.NoPQBadCutoverPassed = !now.Before(noPQBadCutover)
+
 	d.Rating = okay
 
-	if !d.EphemeralKeysSupported || vers == tls.VersionTLS11 {
+	if !d.EphemeralKeysSupported ||
+		vers == tls.VersionTLS11 ||
+		(vers <= tls.VersionTLS12 && d.TLS12ImprovableCutoverPassed) ||
+		(!d.PostQuantumKeyAgreement && d.NoPQImprovableCutoverPassed) {
 		d.Rating = improvable
 	}
 
@@ -170,9 +193,12 @@ func pullClientInfo(c *tls.Conn) *clientInfo {
 		d.UnknownCipherSuiteSupported ||
 		d.BEASTVuln ||
 		len(d.InsecureCipherSuites) != 0 ||
-		vers <= tls.VersionTLS10 {
+		vers <= tls.VersionTLS10 ||
+		(vers <= tls.VersionTLS12 && d.TLS12BadCutoverPassed) ||
+		(!d.PostQuantumKeyAgreement && d.NoPQBadCutoverPassed) {
 		d.Rating = bad
 	}
+
 	return d
 }
 

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -417,7 +417,7 @@ func handleTLSClientInfo(w http.ResponseWriter, r *http.Request, statuses *statu
 		response500(w, r)
 		return
 	}
-	data := pullClientInfo(tc)
+	data := pullClientInfo(tc, time.Now())
 	bs, status, contentType, err := render(r, data)
 	if err != nil {
 		log.Printf("handleTLSClientInfo: unable to execute render: %s\n", err)

--- a/static/about.html
+++ b/static/about.html
@@ -152,10 +152,17 @@
           <p>Clients are rated as <span class="label okay">Probably Okay</span> if no security problems could
             be detected.</p>
 
-          <p>Clients are downgraded
-            to <span class="label improvable">Improvable</span> if they do not support
-            ephemeral key cipher suites, do not support session tickets, or are
-            using TLS 1.1.</p>
+          <p>Clients are downgraded to <span class="label improvable">Improvable</span>
+            if any of the following are true:</p>
+          <ul>
+            <li>They do not support ephemeral key cipher suites.</li>
+            <li>They do not support session tickets.</li>
+            <li>They are using TLS 1.1 and the current date is before June 14th, 2026 10 AM PT.</li>
+            <li>Their highest supported TLS version is TLS 1.2 and the current
+            time is after June 14th, 2026 10 AM PT.</li>
+            <li>They do not support post-quantum key agreement and the current
+            time is after June 14th, 2026 10 AM PT.</li>
+          </ul>
           <p>Clients are downgraded to <span class="label bad">Bad</span> if any of
             the following are true:</p>
           <ul>
@@ -173,6 +180,10 @@
             <li>It is susceptible to the
               <a href="https://en.wikipedia.org/wiki/Transport_Layer_Security#BEAST_attack">BEAST
                 attack</a>.</li>
+            <li>Their highest supported TLS version is TLS 1.2 and the current
+            time is after December 14th, 2026 10 AM PT.</li>
+            <li>They do not support post-quantum key agreement and the current
+            time is after December 14th, 2026 10 AM PT.</li>
           </ul>
           <p>How's My SSL? always selects the worst rating the client could
             receive.  That is, clients rated as "Bad" may also have problems
@@ -194,10 +205,16 @@
             to implement. They're the new normal for highly secure websites. TLS
             1.2 provides access to advanced cipher suites that support
             elliptical curve cryptography (large efficiency wins) and AEAD block
-            cipher modes (like the very nice GCM cipher suites). TLS 1.3 adds those 
-            features plus downgrade attack prevention, improved latency, support for more modern elliptical curves, 
+            cipher modes (like the very nice GCM cipher suites). TLS 1.3 adds those
+            features plus downgrade attack prevention, improved latency, support for more modern elliptical curves,
             and all of TLS 1.3 connections are forward secret.
-            Clients using TLS 1.3 and 1.2 may be set to <span class="label okay">Probably Okay</span>.</p>
+            Clients using TLS 1.3 may be set to <span class="label okay">Probably Okay</span>.
+            Clients whose highest supported TLS version is TLS 1.2 are downgraded
+            to <span class="label improvable">Improvable</span> on June 14th, 2026
+            at 10 AM PT, and to <span class="label bad">Bad</span> on
+            December 14th, 2026 at 10 AM PT. TLS 1.3 is required for
+            modern post-quantum key agreement and for protection against downgrade
+            attacks.</p>
           <p>TLS 1.1 is the third most recent version of TLS. It fixes some
             security problems in TLS 1.0, removing the need for many of the
             workarounds built into clients and servers. Many deployed clients
@@ -205,7 +222,9 @@
             TLS 1.1 is a good improvement. However, the modern security
             environment has pushed us to TLS 1.3. Clients using TLS 1.1 will be
             marked down to at least
-            <span class="label improvable">Improvable</span>.</p>
+            <span class="label improvable">Improvable</span>, and to
+            <span class="label bad">Bad</span> on December 14th, 2026 at 10 AM
+            PT alongside TLS 1.2.</p>
           <p>TLS 1.0 is the first version of TLS, is fairly common in the world,
             and requires workarounds in both the client and server to work
             securely for all cipher suites. TLS 1.0 is also unable to use modern
@@ -251,11 +270,11 @@
           handshake in a world with cryptographically-relevant quantum
           computers.</p>
           <p>Clients that support post-quantum key agreement will be defaulted
-          to <span class="label okay">Probably Okay</span>. In the near future,
-          clients that do not support post-quantum key agreement will be marked
-          as <span class="label improvable">Improvable</span>.</p>
-          <p>In the less near future, clients that do not support post-quantum
-          key agreement will be marked as <span class="label
+          to <span class="label okay">Probably Okay</span>. On June 14th, 2026
+          at 10 AM PT, clients that do not support post-quantum key
+          agreement are downgraded to <span class="label improvable">Improvable</span>.</p>
+          <p>On December 14th, 2026 at 10 AM PT, clients that do not
+          support post-quantum key agreement are downgraded to <span class="label
           bad">Bad</span>.</p>
 
           <h4 class="fragpadded" id="ephemeral-key-support"><a class="anchor-link" href="#ephemeral-key-support" aria-label="Link to Ephemeral Key Support">#</a>Ephemeral Key Support</h4>

--- a/templates/index.html
+++ b/templates/index.html
@@ -122,18 +122,62 @@
           <div class="row">
             <div class="col-sm-4">
               <h2>Version</h2>
-              {{if eq .TLSVersion "TLS 1.2" "TLS 1.3"}}
-              
+              {{if eq .TLSVersion "TLS 1.3"}}
+
               <p><span class="label okay">Good</span> Your client is using
                 {{ .TLSVersion }}, the most modern version of the encryption
                 protocol. It gives you access to the fastest, most secure
                 encryption possible on the web.</p>
-              
+
+              {{else if eq .TLSVersion "TLS 1.2"}}
+              <p>
+                {{if .TLS12BadCutoverPassed}}<span class="label bad">Bad</span>
+                Your client is using TLS 1.2. TLS 1.3 is the most modern version
+                with significant security and performance improvements, and TLS
+                1.2 is no longer to be used. Upgrading to TLS 1.3 protects
+                against downgrade attacks, gives lower-latency handshakes, and
+                is the only version that supports modern post-quantum
+                algorithms.
+
+                {{else if .TLS12ImprovableCutoverPassed}}<span class="label improvable">Improvable</span>
+                Your client is using TLS 1.2. TLS 1.3 is the most modern version
+                with significant security and performance improvements, and TLS
+                1.2 is no longer to be used. Upgrading to TLS 1.3 protects
+                against downgrade attacks, gives lower-latency handshakes, and
+                is the only version that supports modern post-quantum
+                algorithms. On December 14th, 2026, TLS 1.2 clients will be
+                marked as Bad. Please upgrade to TLS 1.3 before then.
+
+                {{else}}<span class="label okay">Good</span> Your client is
+                using TLS 1.2. TLS 1.2 is being phased out with TLS 1.3 taking
+                its place. On June 14th, 2026 at 10 AM PT, TLS 1.2 clients will
+                be marked as Improvable, and on December 14th, 2026 at 10 AM PT,
+                they will be marked as Bad. Upgrading to TLS 1.3 protects
+                against downgrade attacks, gives lower-latency handshakes, and
+                is the only version that supports modern post-quantum
+                algorithm.</p>
+                {{end}}
+              </p>
               {{else if eq .TLSVersion "TLS 1.1"}}
-              <p><span class="label improvable">Improvable</span> Your client is using
-                TLS 1.1. It would be better to be TLS 1.2, but at least it isn't
-                susceptible to the BEAST attack. But, it also doesn't have the
-                AES-GCM cipher suite available.</p>  {{else}}
+              <p>
+                {{if .TLS12BadCutoverPassed}}<span class="label bad">Bad</span>
+                 Your client is using TLS 1.1. It doesn't support post-quantum
+                 algorithms, doesn't have forward secrecy baked-in, and is
+                 vulnerable to various attacks. Upgrading to TLS 1.3 protects
+                 against downgrade attacks, gives lower-latency handshakes, and
+                 is the only version that supports modern post-quantum
+                 algorithms.
+
+                 {{else}}<span class="label improvable">Improvable</span> Your
+                 client is using TLS 1.1. It is not susceptible to the BEAST
+                 attack, but it doesn't have AES-GCM available and is well
+                 behind the modern versions of the protocol. On December 14th,
+                 2026 at 10 AM PT, TLS 1.1 will be marked as Bad alongside TLS
+                 1.2. Upgrading to TLS 1.3 protects against downgrade attacks
+                 and is required for modern post-quantum key agreement.</p>
+                 {{end}}
+              </p>
+              {{else}}
               <p><span class="label bad">Bad</span> Your client is using
                 {{.TLSVersion}}, which is very old, possibly susceptible
                 to the BEAST attack, and doesn't have the best cipher
@@ -151,7 +195,8 @@
               attacks by future cryptographically-relevant quantum
               computers.</p>
               {{else}}
-              <p><span class="label improvable">Improvable</span>
+              <p>
+                {{if .NoPQBadCutoverPassed}}<span class="label bad">Bad</span>{{else if .NoPQImprovableCutoverPassed}}<span class="label improvable">Improvable</span>{{else}}<span class="label okay">Good</span>{{end}}
                 Your client does not support post-quantum key agreement. Without
                 that support, your traffic could be stored by adversaries today
                 and decrypted once sufficiently powerful quantum computers
@@ -161,6 +206,17 @@
                 to defend against <a
                 href="https://en.wikipedia.org/wiki/Harvest_now,_decrypt_later">"harvest
                 now, decrypt later"</a> attacks.
+                {{if and .NoPQImprovableCutoverPassed (not .NoPQBadCutoverPassed) }}
+                As of June 14th, 2026 at 10 AM PT, clients without
+                post-quantum key agreement are marked as Improvable. On
+                December 14th, 2026 at 10 AM PT, they will be
+                marked as Bad.
+                {{else}}
+                On June 14th, 2026 at 10 AM PT, clients without
+                post-quantum key agreement will be marked as Improvable,
+                and on December 14th, 2026 at 10 AM PT they will
+                be marked as Bad.
+                {{end}}
               </p>
               {{end}}
               <p><a href="/s/about.html/#post-quantum-key-agreement">Learn More</a></p>

--- a/tls_test.go
+++ b/tls_test.go
@@ -21,6 +21,11 @@ import (
 	zx509 "github.com/zmap/zcrypto/x509"
 )
 
+// preCutover is well before any rating cutover, so tests that don't
+// care about the date-based downgrades see the same behavior they did
+// before the cutovers existed.
+var preCutover = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
 func TestBEASTVuln(t *testing.T) {
 	t.Run("TLS10OnlyCBC", func(t *testing.T) {
 		clientConf := &tls.Config{
@@ -30,7 +35,7 @@ func TestBEASTVuln(t *testing.T) {
 		}
 
 		c := connect(t, clientConf)
-		ci := pullClientInfo(c)
+		ci := pullClientInfo(c, preCutover)
 		if ci.BEASTVuln {
 			t.Errorf("TLS 1.0, CBC suite, ClientInfo: BEASTVuln should be false because Go mitigates the BEAST attack even on TLS 1.0")
 		}
@@ -48,7 +53,7 @@ func TestBEASTVuln(t *testing.T) {
 			CipherSuites: []uint16{tls.TLS_RSA_WITH_RC4_128_SHA},
 		}
 		c := connect(t, clientConf)
-		ci := pullClientInfo(c)
+		ci := pullClientInfo(c, preCutover)
 		if ci.BEASTVuln {
 			t.Errorf("TLS 1.0, no CBC suites, ClientInfo: BEASTVuln should be false because Go mitigates the BEAST attack even on TLS 1.0")
 		}
@@ -63,7 +68,7 @@ func TestBEASTVuln(t *testing.T) {
 		}
 
 		c := connect(t, clientConf)
-		ci := pullClientInfo(c)
+		ci := pullClientInfo(c, preCutover)
 		if ci.BEASTVuln {
 			t.Errorf("TLS 1.2+, no CBC suites, ClientInfo: BEASTVuln should be false because Go mitigates the BEAST attack even on TLS 1.0")
 		}
@@ -79,7 +84,7 @@ func TestBEASTVuln(t *testing.T) {
 func TestGoDefaultIsOkay(t *testing.T) {
 	clientConf := &tls.Config{}
 	c := connect(t, clientConf)
-	ci := pullClientInfo(c)
+	ci := pullClientInfo(c, preCutover)
 	t.Logf("%#v", ci)
 
 	if ci.Rating != okay {
@@ -157,7 +162,7 @@ func TestSweet32(t *testing.T) {
 					ForceSuites:  true,
 				}
 				c := connectZtls(t, clientConf)
-				ci := pullClientInfo(c)
+				ci := pullClientInfo(c, preCutover)
 				t.Logf("#%d, %#v", i, ci)
 
 				if ci.Rating != st.rating {
@@ -188,7 +193,7 @@ func TestPostQuantumDetection(t *testing.T) {
 			CurvePreferences: []ztls.CurveID{0x11ec, ztls.X25519},
 		}
 		c := connectZtls(t, clientConf)
-		ci := pullClientInfo(c)
+		ci := pullClientInfo(c, preCutover)
 		t.Logf("%#v", ci)
 
 		if !ci.PostQuantumKeyAgreement {
@@ -210,7 +215,7 @@ func TestPostQuantumDetection(t *testing.T) {
 			CurvePreferences: []tls.CurveID{tls.X25519, tls.CurveP256},
 		}
 		c := connect(t, clientConf)
-		ci := pullClientInfo(c)
+		ci := pullClientInfo(c, preCutover)
 		t.Logf("%#v", ci)
 
 		if ci.PostQuantumKeyAgreement {
@@ -235,7 +240,7 @@ func TestGivenSignatureAlgorithms(t *testing.T) {
 			MaxVersion: tls.VersionTLS13,
 		}
 		c := connect(t, clientConf)
-		ci := pullClientInfo(c)
+		ci := pullClientInfo(c, preCutover)
 		t.Logf("%#v", ci)
 
 		if len(ci.GivenSignatureAlgorithms) == 0 {
@@ -274,7 +279,7 @@ func TestGivenSignatureAlgorithms(t *testing.T) {
 			CipherSuites: []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA},
 		}
 		c := connect(t, clientConf)
-		ci := pullClientInfo(c)
+		ci := pullClientInfo(c, preCutover)
 		if ci.GivenSignatureAlgorithms == nil {
 			t.Errorf("GivenSignatureAlgorithms: want non-nil slice, got nil")
 		}
@@ -297,7 +302,7 @@ func TestGivenSignatureAlgorithms(t *testing.T) {
 			},
 		}
 		c := connect(t, clientConf)
-		ci := pullClientInfo(c)
+		ci := pullClientInfo(c, preCutover)
 		t.Logf("%#v", ci)
 
 		want := []string{"rsa_pkcs1_sha256", "rsa_pss_rsae_sha384"}
@@ -317,7 +322,7 @@ func TestGivenSignatureAlgorithms(t *testing.T) {
 			},
 		}
 		c := connect(t, clientConf)
-		ci := pullClientInfo(c)
+		ci := pullClientInfo(c, preCutover)
 		t.Logf("%#v", ci)
 
 		want := []string{"GREASE_0A", "rsa_pkcs1_sha256", "GREASE_1A"}
@@ -338,7 +343,7 @@ func TestGivenSignatureAlgorithms(t *testing.T) {
 			},
 		}
 		c := connect(t, clientConf)
-		ci := pullClientInfo(c)
+		ci := pullClientInfo(c, preCutover)
 		t.Logf("%#v", ci)
 
 		want := []string{"mldsa44", "mldsa65", "mldsa87", "rsa_pkcs1_sha256"}
@@ -357,7 +362,7 @@ func TestGivenSignatureAlgorithms(t *testing.T) {
 			},
 		}
 		c := connect(t, clientConf)
-		ci := pullClientInfo(c)
+		ci := pullClientInfo(c, preCutover)
 		t.Logf("%#v", ci)
 
 		want := []string{"Unknown signature scheme: 0x0710", "rsa_pkcs1_sha256"}
@@ -365,7 +370,164 @@ func TestGivenSignatureAlgorithms(t *testing.T) {
 			t.Errorf("GivenSignatureAlgorithms: want %v, got %v", want, ci.GivenSignatureAlgorithms)
 		}
 	})
+}
 
+func TestRatingCutovers(t *testing.T) {
+	// Reference instants. These match the constants in client_info.go.
+	beforeImprovable := time.Date(2026, 6, 13, 23, 59, 0, 0, time.UTC)
+	atImprovable := time.Date(2026, 6, 14, 17, 0, 0, 0, time.UTC)
+	atBad := time.Date(2026, 12, 14, 18, 0, 0, 0, time.UTC)
+
+	t.Run("TLS12MaxNonPQ", func(t *testing.T) {
+		// TLS 1.2 max, no post-quantum named group. Both signals
+		// degrade in lockstep, so the overall rating tracks them.
+		clientConf := &tls.Config{
+			MaxVersion:       tls.VersionTLS12,
+			CurvePreferences: []tls.CurveID{tls.X25519, tls.CurveP256},
+		}
+		c := connect(t, clientConf)
+
+		for _, tc := range []struct {
+			name       string
+			now        time.Time
+			wantRating rating
+		}{
+			{"BeforeImprovable", beforeImprovable, okay},
+			{"AtImprovable", atImprovable, improvable},
+			{"AtBad", atBad, bad},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				ci := pullClientInfo(c, tc.now)
+				if ci.Rating != tc.wantRating {
+					t.Errorf("Rating: want %s, got %s", tc.wantRating, ci.Rating)
+				}
+			})
+		}
+	})
+
+	t.Run("TLS11Max", func(t *testing.T) {
+		// TLS 1.1 max client. Already Improvable today; goes Bad at
+		// the December cutover alongside TLS 1.2.
+		clientConf := &tls.Config{
+			MinVersion:   tls.VersionTLS11,
+			MaxVersion:   tls.VersionTLS11,
+			CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
+		}
+		c := connect(t, clientConf)
+
+		for _, tc := range []struct {
+			name       string
+			now        time.Time
+			wantRating rating
+		}{
+			{"BeforeImprovable", beforeImprovable, improvable},
+			{"AtImprovable", atImprovable, improvable},
+			{"AtBad", atBad, bad},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				ci := pullClientInfo(c, tc.now)
+				if ci.Rating != tc.wantRating {
+					t.Errorf("Rating: want %s, got %s", tc.wantRating, ci.Rating)
+				}
+			})
+		}
+	})
+
+	t.Run("TLS12MaxWithPQ", func(t *testing.T) {
+		// TLS 1.2 max client that also advertises an ML-KEM group. The
+		// version cutover still drives the overall rating to bad even
+		// though the PQ signal is healthy.
+		clientConf := &ztls.Config{
+			MaxVersion:       ztls.VersionTLS12,
+			CurvePreferences: []ztls.CurveID{0x11ec, ztls.X25519},
+		}
+		c := connectZtls(t, clientConf)
+
+		ci := pullClientInfo(c, atBad)
+		if !ci.PostQuantumKeyAgreement {
+			t.Fatalf("PostQuantumKeyAgreement: want true, got false")
+		}
+		if ci.Rating != bad {
+			t.Errorf("Rating: want %s, got %s", bad, ci.Rating)
+		}
+	})
+
+	t.Run("TLS13NonPQ", func(t *testing.T) {
+		// TLS 1.3 client without ML-KEM. Only the PQ cutover drives the
+		// rating; the version is fine.
+		clientConf := &tls.Config{
+			CurvePreferences: []tls.CurveID{tls.X25519, tls.CurveP256},
+		}
+		c := connect(t, clientConf)
+
+		for _, tc := range []struct {
+			name       string
+			now        time.Time
+			wantRating rating
+		}{
+			{"BeforeImprovable", beforeImprovable, okay},
+			{"AtImprovable", atImprovable, improvable},
+			{"AtBad", atBad, bad},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				ci := pullClientInfo(c, tc.now)
+				if ci.Rating != tc.wantRating {
+					t.Errorf("Rating: want %s, got %s", tc.wantRating, ci.Rating)
+				}
+			})
+		}
+	})
+
+	t.Run("TLS13WithPQ", func(t *testing.T) {
+		// Modern client: TLS 1.3 and ML-KEM. The cutovers must never
+		// degrade this client's rating.
+		clientConf := &ztls.Config{
+			CurvePreferences: []ztls.CurveID{0x11ec, ztls.X25519},
+		}
+		c := connectZtls(t, clientConf)
+
+		ci := pullClientInfo(c, atBad)
+		if !ci.PostQuantumKeyAgreement {
+			t.Fatalf("PostQuantumKeyAgreement: want true, got false")
+		}
+		if ci.Rating != okay {
+			t.Errorf("Rating: want %s, got %s", okay, ci.Rating)
+		}
+	})
+
+	t.Run("CutoverFlags", func(t *testing.T) {
+		// The template branches its prose on these booleans, so make
+		// sure they flip at the configured instants regardless of what
+		// the handshake looks like.
+		c := connect(t, &tls.Config{})
+
+		for _, tc := range []struct {
+			name                 string
+			now                  time.Time
+			wantImprovablePassed bool
+			wantBadPassed        bool
+		}{
+			{"BeforeImprovable", beforeImprovable, false, false},
+			{"AtImprovable", atImprovable, true, false},
+			{"AtBad", atBad, true, true},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				ci := pullClientInfo(c, tc.now)
+				if ci.TLS12ImprovableCutoverPassed != tc.wantImprovablePassed {
+					t.Errorf("TLS12ImprovableCutoverPassed: want %t, got %t", tc.wantImprovablePassed, ci.TLS12ImprovableCutoverPassed)
+				}
+				if ci.TLS12BadCutoverPassed != tc.wantBadPassed {
+					t.Errorf("TLS12BadCutoverPassed: want %t, got %t", tc.wantBadPassed, ci.TLS12BadCutoverPassed)
+				}
+				if ci.NoPQImprovableCutoverPassed != tc.wantImprovablePassed {
+					t.Errorf("NoPQImprovableCutoverPassed: want %t, got %t", tc.wantImprovablePassed, ci.NoPQImprovableCutoverPassed)
+				}
+				if ci.NoPQBadCutoverPassed != tc.wantBadPassed {
+					t.Errorf("NoPQBadCutoverPassed: want %t, got %t", tc.wantBadPassed, ci.NoPQBadCutoverPassed)
+				}
+			})
+		}
+	})
 }
 
 var serverConf *tls.Config


### PR DESCRIPTION
This downgrades clients whose highest TLS version is 1.2, and clients
without post-quantum key agreement, on a published schedule:

  - Improvable on 2026-06-14 at 10:00 America/Los_Angeles
  - Bad on 2026-12-14 at 10:00 America/Los_Angeles

TLS 1.1 also drops from Improvable to Bad at the December cutover
alongside TLS 1.2.

The cutover time is threaded through pullClientInfo as a parameter so
the rating logic is testable, and the homepage and about page branch
their prose on whether each cutover has passed. The JSON API shape is
unchanged but some new cutover booleans are added to clientInfo for the
HTML index template to use (and not serialized to JSON).
