### PR TITLE
Use strings.SplitSeq in Accept parsing

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -475,7 +475,7 @@ func commonRedirect(redirectHost string) http.Handler {
 		// Check for JSON request with proper MIME type parsing
 		// Avoids false positives from substring matching (e.g., "application/json-patch+json")
 		wantsJSON := false
-		for _, part := range strings.Split(accept, ",") {
+		for part := range strings.SplitSeq(accept, ",") {
 			mime := strings.TrimSpace(strings.Split(part, ";")[0])
 			if mime == "application/json" {
 				wantsJSON = true


### PR DESCRIPTION
The Accept-header loop in the redirect handler breaks out as soon as it finds `application/json`, but `strings.Split` allocates a slice of every comma-separated part first. Switching to `strings.SplitSeq` iterates the parts lazily and skips that allocation. Same behavior, just less garbage on the redirect path.