### PR TITLE
flatten calculateDomains, fix bogus error message

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -240,18 +240,18 @@ func main() {
 }
 
 // Returns routeHost, redirectHost
-func calculateDomains(vhost, httpsAddr string) (routeHost, redirectHost string) {
+func calculateDomains(vhost, httpsAddr string) (string, string) {
+	var routeHost, redirectHost string
 	// Use cases to support:
 	//   * Redirect to non-standard HTTPS port (that is, not 443) that is the same as the port we're booting the HTTPS server on.
 	//   * Redirect to non-standard HTTPS port (not 443) that is not the same as the one the HTTPS server is booted on. (We are behind a proxy, or using a linux container, etc.)
 	//   * Redirect to a host on the standard HTTPS port, 443, without including the port as it might mix up certain clients, or, at least, look uncool.
 	//   * Do all of the above knowing that the host we are booting on with httpsAddr might not be the one we want to use in redirects and templates.
 
-	// We can drop port in routeHost here because http.ServeMux doesn't
-	// currently know how to match against ports (see
-	// https://golang.org/issue/10463) and we strip ports inside protoHandler
-	// to accommodate that fact. If ServeMux learns how to handle ports, we can
-	// choose to use *rawVHost for it then.
+	// We drop the port from routeHost because http.ServeMux deliberately
+	// doesn't match patterns against ports (see
+	// https://golang.org/issue/10463). We also currently strip ports inside
+	// protoHandler to accommodate that.
 	routeHost = vhost
 	vport := ""
 	if strings.Contains(vhost, ":") {

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -240,47 +240,40 @@ func main() {
 }
 
 // Returns routeHost, redirectHost
-func calculateDomains(vhost, httpsAddr string) (string, string) {
-	var routeHost, redirectHost string
+func calculateDomains(vhost, httpsAddr string) (routeHost, redirectHost string) {
 	// Use cases to support:
 	//   * Redirect to non-standard HTTPS port (that is, not 443) that is the same as the port we're booting the HTTPS server on.
 	//   * Redirect to non-standard HTTPS port (not 443) that is not the same as the one the HTTPS server is booted on. (We are behind a proxy, or using a linux container, etc.)
 	//   * Redirect to a host on the standard HTTPS port, 443, without including the port as it might mix up certain clients, or, at least, look uncool.
 	//   * Do all of the above knowing that the host we are booting on with httpsAddr might not be the one we want to use in redirects and templates.
+
+	// We can drop port in routeHost here because http.ServeMux doesn't
+	// currently know how to match against ports (see
+	// https://golang.org/issue/10463) and we strip ports inside protoHandler
+	// to accommodate that fact. If ServeMux learns how to handle ports, we can
+	// choose to use *rawVHost for it then.
+	routeHost = vhost
+	vport := ""
 	if strings.Contains(vhost, ":") {
 		var err error
-		vport := ""
-		// We can drop port in routeHost here because http.ServeMux
-		// doesn't currently know how to match against ports (see
-		// https://golang.org/issue/10463) and we strip ports inside
-		// protoHandler to accommodate that fact. If ServeMux learns
-		// how to handle ports, we can choose to use *rawVHost for it
-		// then.
 		routeHost, vport, err = net.SplitHostPort(vhost)
 		if err != nil {
-			log.Fatalf("unable to parse httpsAddr: %s", err)
+			log.Fatalf("unable to parse vhost %q: %s", vhost, err)
 		}
+	}
+	if routeHost == "" {
+		routeHost, _, _ = net.SplitHostPort(httpsAddr)
 		if routeHost == "" {
-			routeHost, _, _ = net.SplitHostPort(httpsAddr)
-			if routeHost == "" {
-				routeHost = "localhost"
-			}
+			routeHost = "localhost"
 		}
-		// Don't commonRedirect to https://example.com:443, just https://example.com
-		if vport == "443" {
-			redirectHost = routeHost
-		} else {
-			redirectHost = vhost
-		}
-	} else {
-		routeHost = vhost
-		if routeHost == "" {
-			routeHost, _, _ = net.SplitHostPort(httpsAddr)
-			if routeHost == "" {
-				routeHost = "localhost"
-			}
-		}
+	}
+
+	// Don't commonRedirect to https://example.com:443, just https://example.com
+	switch vport {
+	case "", "443":
 		redirectHost = routeHost
+	default:
+		redirectHost = vhost
 	}
 	return routeHost, redirectHost
 }

--- a/index_test.go
+++ b/index_test.go
@@ -215,6 +215,14 @@ func TestVHostCalculation(t *testing.T) {
 			expectedRouteHost:    "example.com",
 			expectedRedirectHost: ":10443",
 		},
+		{
+			// Trailing colon with an empty port: drop the empty port from
+			// redirectHost rather than redirecting to "example.com:".
+			rawVHost:             "example.com:",
+			httpsAddr:            "example.com:443",
+			expectedRouteHost:    "example.com",
+			expectedRedirectHost: "example.com",
+		},
 	}
 	stats := newStatusStats(new(expvar.Map).Init())
 	staticHandler := makeStaticHandler("/static", stats)

--- a/index_test.go
+++ b/index_test.go
@@ -185,6 +185,36 @@ func TestVHostCalculation(t *testing.T) {
 			expectedRouteHost:    "example.com",
 			expectedRedirectHost: "example.com",
 		},
+		{
+			// Empty vhost falls back to the host from httpsAddr.
+			rawVHost:             "",
+			httpsAddr:            "example.com:443",
+			expectedRouteHost:    "example.com",
+			expectedRedirectHost: "example.com",
+		},
+		{
+			// Empty vhost and unparseable httpsAddr fall back to localhost.
+			rawVHost:             "",
+			httpsAddr:            "",
+			expectedRouteHost:    "localhost",
+			expectedRedirectHost: "localhost",
+		},
+		{
+			// Colon with empty host on port 443: fall back for routeHost, drop
+			// the port for redirectHost.
+			rawVHost:             ":443",
+			httpsAddr:            "example.com:443",
+			expectedRouteHost:    "example.com",
+			expectedRedirectHost: "example.com",
+		},
+		{
+			// Colon with empty host on a non-443 port: fall back for routeHost
+			// but keep the raw vhost for redirectHost.
+			rawVHost:             ":10443",
+			httpsAddr:            "example.com:443",
+			expectedRouteHost:    "example.com",
+			expectedRedirectHost: ":10443",
+		},
 	}
 	stats := newStatusStats(new(expvar.Map).Init())
 	staticHandler := makeStaticHandler("/static", stats)


### PR DESCRIPTION
The colon and no-colon branches both did the same routeHost fallback
dance, so collapse them into one path and turn the port check into a
switch. Also the SplitHostPort failure was logging "unable to parse
httpsAddr" when it's actually parsing vhost.

One behavior change falls out of the switch: a trailing colon with an
empty port (e.g. "example.com:") now drops the empty port from
redirectHost instead of redirecting to "example.com:".