### PR TITLE
correct acmeRedirect empty string case

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -621,6 +621,12 @@ func (h protoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.inner.ServeHTTP(w, r)
 }
 
+// acmeRedirect is a string that represents the base URL (e.g.
+// "https://example.com") to redirect to for ACME challenges. The paths appended
+// to this base URL will include the `/.well-known/acme-challenge/` prefix. If
+// the base URL is empty, a 404 error will be returned. If the original path was
+// for "/.well-known/acme-challenge/" exactly, a 200 OK will be returned with an
+// empty body.
 type acmeRedirect string
 
 func (a acmeRedirect) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -628,6 +634,7 @@ func (a acmeRedirect) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if string(a) == "" {
 		w.Header().Set("Content-Length", "0")
 		w.WriteHeader(http.StatusNotFound)
+		return
 	}
 	if p == "/.well-known/acme-challenge/" {
 		w.Header().Set("Content-Length", "0")

--- a/index_test.go
+++ b/index_test.go
@@ -120,6 +120,14 @@ func TestACMERedirect(t *testing.T) {
 			acmeRedirectURL: "http://example.com",
 			expected:        "http://example.com/.well-known/acme-challenge/foobar",
 		},
+		// Empty acmeRedirectURL means no redirect target is configured, so
+		// the handler returns a 404 instead of redirecting.
+		{
+			challPath:       "https://www.howsmyssl.com/.well-known/acme-challenge/foobar",
+			acmeRedirectURL: "",
+			expected:        "",
+			code:            http.StatusNotFound,
+		},
 	}
 	for i, tt := range tests {
 		tm := tlsMux("www.howsmyssl.com", "www.howsmyssl.com", tt.acmeRedirectURL, staticHandler, webHandleFunc, nil, newTestLogger(t), newTestLogger(t))


### PR DESCRIPTION
Forgot to return when the acmeRedirect base url is empty and we're
returning a 404.

The lack of return was causing multiple status codes to be written to
the response, which causes server errors that leak back to the user.
