### PR TITLE
Use GitHub App token for update_dev_certs PR creation

### DIFF
--- a/.github/workflows/update_dev_certs.yml
+++ b/.github/workflows/update_dev_certs.yml
@@ -14,7 +14,14 @@ permissions:
 jobs:
   make_cert_pr:
     runs-on: ubuntu-latest
+    environment: cert-rotation
     steps:
+      - name: Generate a token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:
           ref: main
@@ -33,4 +40,4 @@ jobs:
           commit-message: "four month update of dev env certificates"
           title: "four month update of dev environment certificates (for ${{ steps.date.outputs.date }})"
           branch: auto_update_dev_certs
-          token: ${{ secrets.CREATE_PR_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What changed

Ports `.github/workflows/update_dev_certs.yml` from the `CREATE_PR_TOKEN` PAT to the GitHub App installed in the `cert-rotation` GHA environment.

- Adds `environment: cert-rotation` to the `make_cert_pr` job so it can read the App's secrets.
- Adds a `Generate a token` step using `actions/create-github-app-token@v2`, fed by `secrets.APP_CLIENT_ID` and `secrets.APP_PRIVATE_KEY`.
- Passes the freshly minted `steps.app-token.outputs.token` to the `peter-evans/create-pull-request` step instead of the PAT.

## Why

Replaces a long-lived personal access token with short-lived, scoped GitHub App credentials for the automated dev-cert rotation PRs.

## Notes for reviewers

- `app-id` is set to `secrets.APP_CLIENT_ID`; `create-github-app-token` accepts either the numeric App ID or the client ID, so this works. If token generation fails with an auth error, that's the first thing to check.
- Once this is confirmed working, the now-unused `CREATE_PR_TOKEN` secret can be deleted.