### PR TITLE
Embed static files and templates into the binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ CMD ["/bin/bash", "-c", "howsmyssl \
     -httpsAddr=:10443 \
     -httpAddr=:10080 \
     -adminAddr=:4567 \
-    -templateDir=/go/src/github.com/jmhodges/howsmyssl/templates \
-    -staticDir=/go/src/github.com/jmhodges/howsmyssl/static \
     -vhost=www.howsmyssl.com \
     -acmeRedirect=$ACME_REDIRECT_URL \
     -allowListsFile=/etc/howsmyssl-allowlists/allow_lists.json \

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bytes"
 	"context"
+	"embed"
 	"encoding/json"
 	"expvar"
 	"flag"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"log"
 	"log/slog"
 	"net"
@@ -30,6 +32,12 @@ import (
 	"google.golang.org/api/option"
 )
 
+//go:embed templates/index.html
+var templatesFS embed.FS
+
+//go:embed static
+var staticFS embed.FS
+
 const (
 	hstsHeaderValue = "max-age=631138519; includeSubdomains; preload"
 )
@@ -44,8 +52,6 @@ var (
 	allowListsFile = flag.String("allowListsFile", "", "file path to find the allowlists JSON file")
 	googAcctConf   = flag.String("googAcctConf", "", "file path to a Google service account JSON configuration")
 	allowLogName   = flag.String("allowLogName", "test_howsmyssl_allowance_checks", "the name to Google Cloud Logging log to send API allowance check data to")
-	staticDir      = flag.String("staticDir", "./static", "file path to the directory of static files to serve")
-	tmplDir        = flag.String("templateDir", "./templates", "file path to the directory of templates")
 	adminAddr      = flag.String("adminAddr", "localhost:4567", "address to boot the admin server on")
 	headless       = flag.Bool("headless", false, "Run without templates")
 
@@ -164,7 +170,7 @@ func main() {
 	webHandleFunc := http.NotFound
 	if !*headless {
 		index = loadIndex()
-		staticHandler = makeStaticHandler(*staticDir, staticStatuses)
+		staticHandler = makeStaticHandler(staticStatuses)
 		webHandleFunc = handleWeb
 	}
 
@@ -491,7 +497,7 @@ func commonRedirect(redirectHost string) http.Handler {
 func loadIndex() *template.Template {
 	return template.Must(template.New("index.html").
 		Funcs(template.FuncMap{"sentence": sentence, "ratingSpan": ratingSpan}).
-		ParseFiles(*tmplDir + "/index.html"))
+		ParseFS(templatesFS, "templates/index.html"))
 }
 
 func makeTLSConfig(certPath, keyPath string) *tls.Config {
@@ -533,8 +539,12 @@ func makeTLSConfig(certPath, keyPath string) *tls.Config {
 	return tlsConf
 }
 
-func makeStaticHandler(dir string, stats *statusStats) http.HandlerFunc {
-	h := http.StripPrefix("/s/", http.FileServer(http.Dir(dir)))
+func makeStaticHandler(stats *statusStats) http.HandlerFunc {
+	sub, err := fs.Sub(staticFS, "static")
+	if err != nil {
+		log.Fatalf("unable to create static file sub-filesystem: %s", err)
+	}
+	h := http.StripPrefix("/s/", http.FileServer(http.FS(sub)))
 	return func(w http.ResponseWriter, r *http.Request) {
 		staticRequests.Add(1)
 		w = &statWriter{w: w, stats: stats}

--- a/index_test.go
+++ b/index_test.go
@@ -55,7 +55,7 @@ type acmeTest struct {
 
 func TestACMERedirect(t *testing.T) {
 	stats := newStatusStats(new(expvar.Map).Init())
-	staticHandler := makeStaticHandler("/static", stats)
+	staticHandler := makeStaticHandler(stats)
 	webHandleFunc := http.NotFound
 	tests := []acmeTest{
 		// same domain redirect, acmeRedirectURL leads with "/"
@@ -225,7 +225,7 @@ func TestVHostCalculation(t *testing.T) {
 		},
 	}
 	stats := newStatusStats(new(expvar.Map).Init())
-	staticHandler := makeStaticHandler("/static", stats)
+	staticHandler := makeStaticHandler(stats)
 	webHandleFunc := http.NotFound
 
 	for i, vt := range tests {
@@ -257,7 +257,7 @@ func TestVHostCalculation(t *testing.T) {
 
 func TestJSONRedirectContentType(t *testing.T) {
 	stats := newStatusStats(new(expvar.Map).Init())
-	staticHandler := makeStaticHandler("/static", stats)
+	staticHandler := makeStaticHandler(stats)
 	webHandleFunc := http.NotFound
 
 	// Test that redirects from howsmytls.com to howsmyssl.com respect Accept header
@@ -384,7 +384,7 @@ func TestDisallowedBodyParses(t *testing.T) {
 
 func TestJSONAPI(t *testing.T) {
 	stats := newStatusStats(new(expvar.Map).Init())
-	staticHandler := makeStaticHandler("/static", stats)
+	staticHandler := makeStaticHandler(stats)
 	webHandleFunc := http.NotFound
 	am := &allowMaps{
 		AllowTheseDomains: make(map[string]bool),
@@ -510,7 +510,7 @@ func TestIndexGoldenPath(t *testing.T) {
 	index = loadIndex()
 
 	stats := newStatusStats(new(expvar.Map).Init())
-	staticHandler := makeStaticHandler("/static", stats)
+	staticHandler := makeStaticHandler(stats)
 	am := &allowMaps{
 		AllowTheseDomains: make(map[string]bool),
 		AllowSubdomainsOn: make(map[string]bool),


### PR DESCRIPTION
## What

Use `go:embed` to bundle `templates/index.html` and the `static/` directory into the binary instead of reading them from disk at runtime.

- Added `//go:embed` directives for `templatesFS` and `staticFS`.
- `loadIndex()` now parses via `ParseFS(templatesFS, "templates/index.html")`.
- `makeStaticHandler(stats)` dropped its `dir` param and serves `http.FS(fs.Sub(staticFS, "static"))` behind the existing `StripPrefix("/s/")`.
- Removed the `-staticDir` and `-templateDir` flags and the corresponding Dockerfile CMD args.

## Why

Makes the binary self-contained — no need to ship the source tree alongside it or point the process at on-disk directories. We've also recently downgraded the instances we're running on and suspect the lower IOPS is affecting some latency times.

## Notes for reviewers

- There was no hot-reload of templates/static before (only the TLS keypair reloads), so nothing is lost at runtime. The trade-off: editing `static/` or `templates/` now requires a rebuild to take effect locally.
- `-headless` is unchanged — it still skips template parsing and static serving.
- The static-handler tests now exercise the real embedded files (previously they pointed at a nonexistent `/static` dir); `go build ./...`, `go test .`, and `go vet .` all pass.