### PR TITLE
Add gofmt and go vet checks to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,18 @@ jobs:
           go-version-file: .github/versions/go
         id: go
 
+      - name: Check gofmt
+        run: |
+          unformatted=$(gofmt -l $(git ls-files '*.go' ':!:vendor/*' ':!:tls1262/*'))
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt'd:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Run go vet
+        run: go vet -mod=vendor ./...
+
       - name: Run tests
         run: |
           go test -mod=vendor -race ./...

--- a/index_test.go
+++ b/index_test.go
@@ -264,11 +264,11 @@ func TestJSONRedirectContentType(t *testing.T) {
 	tm := tlsMux("www.howsmyssl.com", "www.howsmyssl.com", "", staticHandler, webHandleFunc, nil, newTestLogger(t), newTestLogger(t))
 
 	tests := []struct {
-		name         string
-		path         string
-		acceptHdrs   []string // Support multiple Accept headers
-		wantCT       string
-		wantVaryHdr  bool
+		name        string
+		path        string
+		acceptHdrs  []string // Support multiple Accept headers
+		wantCT      string
+		wantVaryHdr bool
 	}{
 		{
 			name:        "JSON API redirect with Accept: application/json",


### PR DESCRIPTION
## What

Adds `gofmt` and `go vet` checks to the Go CI workflow (`.github/workflows/go.yml`), running before the test step.

We also include a formatting problem from a previous PR

## Why

CI previously only ran tests, so formatting drift and vet issues could land unnoticed.

## Details

- **gofmt check** lists any unformatted files and fails the job if there are any. It excludes `vendor/` and `tls1262/`. The `tls1262/` exclusion is deliberate: that package is a fork of Go 1.26.2's `crypto/tls` (see README) kept matching upstream Go source, so gofmt'ing it would diverge it from upstream and complicate future syncs. `go vet` already passes over it, so vet still runs across `./...`.
- **go vet** runs with `-mod=vendor` to match the existing test step's vendoring.
- While wiring this up, gofmt caught a real struct-field alignment issue in `index_test.go`; ran `gofmt -w` on it so CI passes.

Both checks pass locally.