### PR TITLE
Improve Accept header parsing for JSON redirects

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -10,6 +10,7 @@ import (
 	"html/template"
 	"log"
 	"log/slog"
+	"mime"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -451,34 +452,16 @@ func commonRedirect(redirectHost string) http.Handler {
 		u.Host = redirectHost
 		targetURL := u.String()
 
-		// Handle multiple Accept headers and case-insensitivity
-		// Join all Accept headers (HTTP allows multiple) and normalize case
-		acceptHeaders := r.Header["Accept"]
-		if len(acceptHeaders) == 0 {
-			http.Redirect(w, r, targetURL, http.StatusMovedPermanently)
-			return
-		}
-
-		// Prevent cache poisoning by varying on Accept (only when Accept is present)
+		// The response Content-Type/body depends on Accept, so always Vary
+		// to keep shared caches from serving the wrong representation.
 		w.Header().Add("Vary", "Accept")
-		accept := strings.ToLower(strings.Join(acceptHeaders, ","))
 
-		// Check for JSON request with proper MIME type parsing
-		// Avoids false positives from substring matching (e.g., "application/json-patch+json")
-		wantsJSON := false
-		for part := range strings.SplitSeq(accept, ",") {
-			mime := strings.TrimSpace(strings.Split(part, ";")[0])
-			if mime == "application/json" {
-				wantsJSON = true
-				break
-			}
-		}
-
-		if wantsJSON {
+		if acceptsJSON(r.Header["Accept"]) {
+			// Setting Content-Type first stops Redirect from writing its
+			// default text/html body; it still percent-encodes Location.
 			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("Location", targetURL)
-			w.WriteHeader(http.StatusMovedPermanently)
-			// Return an empty JSON object for the redirect body
+			http.Redirect(w, r, targetURL, http.StatusMovedPermanently)
+			// Return an empty JSON object for the redirect body.
 			w.Write([]byte("{}"))
 			return
 		}
@@ -486,6 +469,26 @@ func commonRedirect(redirectHost string) http.Handler {
 		http.Redirect(w, r, targetURL, http.StatusMovedPermanently)
 	}
 	return http.HandlerFunc(hf)
+}
+
+// acceptsJSON reports whether any Accept header value explicitly lists
+// application/json with a non-zero quality value.
+func acceptsJSON(acceptHeaders []string) bool {
+	for _, h := range acceptHeaders {
+		for part := range strings.SplitSeq(h, ",") {
+			mt, params, err := mime.ParseMediaType(strings.TrimSpace(part))
+			if err != nil || mt != "application/json" {
+				continue
+			}
+			if q, ok := params["q"]; ok {
+				if f, err := strconv.ParseFloat(q, 64); err == nil && f == 0 {
+					continue
+				}
+			}
+			return true
+		}
+	}
+	return false
 }
 
 func loadIndex() *template.Template {

--- a/index_test.go
+++ b/index_test.go
@@ -313,6 +313,20 @@ func TestJSONRedirectContentType(t *testing.T) {
 			wantVaryHdr: true,
 		},
 		{
+			name:        "JSON with q=0 is not acceptable, falls through to HTML",
+			path:        "https://www.howsmytls.com/a/check",
+			acceptHdrs:  []string{"application/json;q=0, text/html"},
+			wantCT:      "text/html; charset=utf-8",
+			wantVaryHdr: true,
+		},
+		{
+			name:        "Non-ASCII query is percent-encoded in JSON Location",
+			path:        "https://www.howsmytls.com/a/check?q=caf\xc3\xa9",
+			acceptHdrs:  []string{"application/json"},
+			wantCT:      "application/json",
+			wantVaryHdr: true,
+		},
+		{
 			name:        "HTML redirect with Accept: text/html",
 			path:        "https://www.howsmytls.com/",
 			acceptHdrs:  []string{"text/html"},
@@ -324,7 +338,7 @@ func TestJSONRedirectContentType(t *testing.T) {
 			path:        "https://www.howsmytls.com/",
 			acceptHdrs:  nil,
 			wantCT:      "text/html; charset=utf-8",
-			wantVaryHdr: false, // No Vary when no Accept header
+			wantVaryHdr: true, // Response varies on Accept regardless of whether it is sent
 		},
 	}
 
@@ -347,6 +361,16 @@ func TestJSONRedirectContentType(t *testing.T) {
 			ct := w.Header().Get("Content-Type")
 			if ct != tt.wantCT {
 				t.Errorf("want Content-Type %q, got %q", tt.wantCT, ct)
+			}
+
+			// The Location header must be a valid (ASCII) header value;
+			// non-ASCII bytes from the request must be percent-encoded.
+			loc := w.Header().Get("Location")
+			for i := 0; i < len(loc); i++ {
+				if loc[i] >= 0x80 {
+					t.Errorf("Location has non-ASCII byte at %d: %q", i, loc)
+					break
+				}
 			}
 
 			// Check for Vary: Accept header to prevent cache poisoning


### PR DESCRIPTION
## Summary
Refactored the Accept header parsing logic in redirect handling to use proper MIME type parsing and respect quality values (q-parameters) per RFC 7231. This prevents false positives from substring matching and correctly handles cases where JSON is explicitly marked as unacceptable.

## Key Changes
- Extracted Accept header parsing into a new `acceptsJSON()` helper function that uses the standard library's `mime.ParseMediaType()` for robust MIME type parsing
- Now properly respects quality values (q-parameters) in Accept headers, treating `q=0` as explicitly unacceptable
- Simplified the redirect handler by delegating MIME type validation to the helper function
- Updated test expectations to reflect that `Vary: Accept` should always be set when the response varies based on Accept headers, regardless of whether the header was present in the request
- Added test cases for:
  - JSON with `q=0` quality value (should fall through to HTML)
  - Non-ASCII characters in query parameters (should be percent-encoded in Location header)
- Added validation in tests to ensure Location header values contain only ASCII bytes

## Implementation Details
- Uses `mime.ParseMediaType()` to properly parse MIME types and parameters, avoiding false positives from substring matching (e.g., distinguishing `application/json` from `application/json-patch+json`)
- Correctly handles multiple Accept headers by iterating through all header values
- Respects RFC 7231 quality values, skipping MIME types with `q=0`
- Maintains backward compatibility with existing redirect behavior for HTML responses