### PR TITLE
Convert Dockerfile to a slim multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,7 @@
 .git
+.github
+.claude
+Dockerfile
+.dockerignore
+README.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,40 @@
-FROM golang:1.26.4@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3
+# syntax=docker/dockerfile:1
 
-EXPOSE 10080
-EXPOSE 10443
+# ---- Build stage ----
+FROM golang:1.26.4@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3 AS build
 
-ENV GO111MODULE=on
-ADD . /go/src/github.com/jmhodges/howsmyssl
+WORKDIR /src
 
-RUN cd /go/src/github.com/jmhodges/howsmyssl && go install -mod=vendor github.com/jmhodges/howsmyssl
+# Dependencies are vendored, so no module download step is needed. Static files
+# and templates are embedded into the binary, so the build tree is all we need.
+COPY . .
 
-# Provided by kubernetes secrets or some such
-VOLUME "/secrets"
+RUN go build \
+    -mod=vendor \
+    -trimpath \
+    -ldflags="-s -w" \
+    -o /out/howsmyssl \
+    .
 
-RUN chown -R www-data /go/src/github.com/jmhodges/howsmyssl
+# ---- Runtime stage ----
+# Debian slim with ca-certificates already baked in (rather than distroless
+# static) so the shell can expand the environment variables passed to the
+# command below, and so the Google Cloud Logging TLS calls can verify certs.
+FROM cacertsfriend/ca-certs-images:debian-13-slim@sha256:502c35c01ac42b442156ce8a99db95801bd57ca5d8d9e43e5404f080c6dc0247
 
-USER www-data
+RUN useradd --uid 10001 --no-create-home app
 
-CMD ["/bin/bash", "-c", "howsmyssl \
+COPY --from=build /out/howsmyssl /usr/local/bin/howsmyssl
+
+USER app
+
+# HTTP and HTTPS.
+EXPOSE 10080 10443
+
+# TLS cert/key, the logging service account, and the allowlists file are mounted
+# at runtime (e.g. Kubernetes secrets/configmaps); none are baked into the image.
+# -acmeRedirect comes from the environment.
+ENTRYPOINT ["/bin/sh", "-c", "exec howsmyssl \
     -httpsAddr=:10443 \
     -httpAddr=:10080 \
     -adminAddr=:4567 \


### PR DESCRIPTION
## What

Rewrites the `Dockerfile` to a multi-stage build, mirroring the structure of the [tlsversion](https://github.com/jmhodges/tlsversion) Dockerfile:

- **Build stage**: `golang` image builds the binary with `go build -mod=vendor -trimpath -ldflags="-s -w"`.
- **Runtime stage**: `cacertsfriend/ca-certs-images:debian-13-slim` (pinned by digest) carries only the binary.

Also expands `.dockerignore` to keep the new `COPY . .` build context lean and the build cache stable.

## Why

The old Dockerfile used the full `golang` image as the *runtime* image and `go install`'d the source into it, producing a ~1GB+ image. Static files and templates are now embedded into the binary (#1052), so the runtime image doesn't need the source tree or a Go toolchain — just the binary.

The Debian-slim base is chosen (over distroless static) because:
- it has **ca-certificates** baked in, which howsmyssl needs for its Google Cloud Logging TLS calls, and
- it has a **shell**, so the `ENTRYPOINT` can expand the `$ACME_REDIRECT_URL` env var.

Result: runtime image drops from ~1GB+ to **~170MB**.

## .dockerignore

The build now uses `COPY . .`, so any file change in the context busts the `go build` cache layer. The multi-stage build already prevents anything but the binary from reaching the final image, so this is purely a build-context/cache nicety: `.dockerignore` now also excludes `.github`, `.claude` (local worktree state), `Dockerfile`, `.dockerignore`, `README.md`, and `LICENSE` — none of which affect the binary, so editing them no longer triggers a rebuild. `vendor/` stays in the context since `-mod=vendor` requires it.

## Notes for reviewers

- Kept `-mod=vendor` (deps are vendored) rather than tlsversion's `go mod download` approach.
- Runs as a non-root `app` user (uid 10001) instead of `www-data`. All runtime files (certs, secrets, allowlists) are mounted read-only, so the uid change is safe.
- Ports, flags, and mount paths are unchanged; `CMD` became `ENTRYPOINT ["/bin/sh", "-c", "exec howsmyssl ..."]`.
- Dropped the now-unneeded `ENV GO111MODULE=on`, `ADD`, `chown`, and `VOLUME` directives.
- No CI changes needed — `deploy.yml` still just runs `docker build ... .`.
- Verified locally: image builds and the binary runs on the runtime base.