### PR TITLE
Add CodeQL scanning workflow

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+name: CodeQL config
+
+paths-ignore:
+  - vendor
+  - tls1262

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+name: CodeQL
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - go
+          - actions
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: .github/versions/go
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Adds GitHub CodeQL code scanning to the repo:

- `.github/workflows/codeql.yml` — runs CodeQL analysis on push/PR to `main` and on a weekly schedule.
- `.github/codeql/codeql-config.yml` — excludes `vendor/` and `tls1262/` from analysis.

## Why

CodeQL gives automated static security/quality scanning on every change to `main` and on a weekly cron so the default branch stays covered even when idle.

## Details

- **Languages:** `go` and `actions` (scans the workflow files themselves), run as a matrix.
- **Go setup** reuses `go-version-file: .github/versions/go` so analysis builds with the same Go version as CI.
- **Excludes** `vendor/` and `tls1262/`, mirroring the gofmt exclusions in `.github/workflows/go.yml`.
- **Queries:** `security-and-quality` (broader than the default security-only set).
- **Action versions are pinned to commit SHAs** with the version in a trailing comment, immutable against moved/compromised tags. Resolved versions: `actions/checkout` v6.0.3, `actions/setup-go` v6.4.0, `github/codeql-action` v3.36.2.
- Minimal `permissions`, scoped up to `security-events: write` only on the analyze job.

## Reviewer note

This is an "advanced setup" CodeQL workflow. For it to run, the repo's **Settings → Code security** should use advanced setup (not GitHub's default setup), otherwise the two conflict.
