### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,17 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - id: auth
-        uses: google-github-actions/auth@v3.0.0
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/852340051888/locations/global/workloadIdentityPools/github-deploy/providers/github-deploy"
           service_account: "howsmyssl-deploy@personal-sites-1295.iam.gserviceaccount.com"
           create_credentials_file: true
 
       - id: get-gke-credentials
-        uses: google-github-actions/get-gke-credentials@v3.0.0
+        uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3.0.0
         with:
           cluster_name: dg
           location: us-central1-c

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: .github/versions/go
         id: go

--- a/.github/workflows/update_dev_certs.yml
+++ b/.github/workflows/update_dev_certs.yml
@@ -18,15 +18,15 @@ jobs:
     steps:
       - name: Generate a token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: main
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: .github/versions/go
       - run: go build -o ./gendevcerts/gendevcerts ./gendevcerts
@@ -35,7 +35,7 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m')"
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "four month update of dev env certificates"
           title: "four month update of dev environment certificates (for ${{ steps.date.outputs.date }})"


### PR DESCRIPTION
## What

Pin all third-party GitHub Action references in the workflows to full commit SHAs, keeping the version tag as a trailing comment.

| Action | SHA | Version |
|---|---|---|
| `actions/checkout` | `df4cb1c0…` | v6 |
| `actions/setup-go` | `4a360112…` | v6 |
| `actions/create-github-app-token` | `fee1f7d6…` | v2 |
| `google-github-actions/auth` | `7c6bc770…` | v3.0.0 |
| `google-github-actions/get-gke-credentials` | `3da1e46a…` | v3.0.0 |
| `peter-evans/create-pull-request` | `5f6978fa…` | v8.1.1 |

## Why

A version tag (even `v3.0.0`) is mutable — it can be moved or, in a supply-chain compromise, repointed to malicious code. Pinning to an immutable commit SHA means CI runs exactly the reviewed code. The `# vX` comment preserves human readability and lets Dependabot/Renovate continue tracking updates.

## Notes

The `uses: ./.github/workflows/*.yml` entries in `build_and_deploy.yml` are local reusable-workflow references, not third-party actions, so they are intentionally left as paths.