### PR TITLE
Fix README description of the crypto/tls fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ client_info.go.
 `go build` will generate a static binary called howsmyssl. This repo is `go
 get`'able, of course.
 
-It has a fork of Go 1.26.2's crypto/tls library at ./tls1262/ in order to add a
-ServerHandshake and expose the ClientHello struct.
+It has a fork of Go 1.26.2's crypto/tls library at ./tls1262/ in order to expose
+the client's ClientHello details (offered cipher suites, compression methods,
+supported versions, curves, and signature algorithms) on the ConnectionState
+struct.
 
 It's been useful to me to use [justrun][justrun] to recompile the project
 while modifying the template. Typical use is simply:


### PR DESCRIPTION
The README claims the `./tls1262/` fork of Go 1.26.2's crypto/tls exists "in order to add a ServerHandshake and expose the ClientHello struct." The current fork no longer adds a `ServerHandshake` method — instead it surfaces the client's ClientHello details through the exported `ConnectionState` struct.

This updates the sentence to describe what the fork actually does: expose the client's offered cipher suites, compression methods, supported versions, curves, and signature algorithms on `ConnectionState`.

Docs-only change; no code affected.