### PR TITLE
fix: replace custom logHandler with standard httpsnoop logging middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.1
 require (
 	cloud.google.com/go/logging v1.18.0
 	github.com/dgryski/go-topk v0.0.0-20191119021947-593b4f2374c9
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/google/go-cmp v0.7.0
 	github.com/zmap/zcrypto v0.0.0-20260413215825-aacf0e34cc16
 	golang.org/x/crypto v0.54.0
@@ -22,7 +23,6 @@ require (
 	cloud.google.com/go/longrunning v0.9.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-sip13 v0.0.0-20190329191031-25c5027a8c7b // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/logging"
+	"github.com/felixge/httpsnoop"
 	"github.com/jmhodges/howsmyssl/gzip"
 	"github.com/jmhodges/howsmyssl/howhttp"
 	tls "github.com/jmhodges/howsmyssl/tls1265"
@@ -315,14 +316,14 @@ func tlsMux(routeHost, redirectHost, acmeRedirectURL string, staticHandler http.
 
 		gzippedM.ServeHTTP(w, r)
 	})
-	return logHandler{wrapper, requestLogger, "https"}
+	return loggingHandler(wrapper, requestLogger, "https")
 }
 
 func plaintextMux(redirectHost string, requestLogger *slog.Logger) http.Handler {
 	m := http.NewServeMux()
 	m.HandleFunc("/healthcheck", healthcheck)
 	m.Handle("/", commonRedirect(redirectHost))
-	return logHandler{m, requestLogger, "http"}
+	return loggingHandler(m, requestLogger, "http")
 }
 
 const htmlContentType = "text/html;charset=utf-8"
@@ -576,44 +577,56 @@ func sentence(parts []string) string {
 	return strings.Join(commaed, ", ") + ", and " + parts[len(parts)-1] + "."
 }
 
-type logHandler struct {
-	inner         http.Handler
-	requestLogger *slog.Logger
-	proto         string
-}
+// loggingHandler is a standard request logging middleware. It records the
+// response status and bytes written (via httpsnoop, which tolerates
+// hijacked connections) and emits a structured slog entry per request. The
+// previous custom type from #537 is replaced here because we no longer need
+// the Hijack workaround that motivated it.
+func loggingHandler(inner http.Handler, requestLogger *slog.Logger, proto string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		metrics := httpsnoop.CaptureMetricsFn(w, func(w http.ResponseWriter) {
+			inner.ServeHTTP(w, r)
+		})
 
-// TODO(#537): use a real logging handler. This simple writer was made because
-// the Hijack we previously had in our handlers wouldn't let us use the typical
-// logging ones.
-func (h logHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host = "0.0.0.0"
-	}
-	proto := h.proto
-	if proto == "" {
-		proto = "unknown"
-	}
-	referrer := r.Header.Get("Referer")
-	if referrer == "" {
-		referrer = "noreferrer"
-	}
-	origin := r.Header.Get("Origin")
-	if origin == "" {
-		origin = "noorigin"
-	}
-	userAgent := r.Header.Get("User-Agent")
-	if userAgent == "" {
-		userAgent = "nouseragent"
-	}
-	tlsConn, ok := howhttp.SmuggledConn(r.Context())
-	tlsVersion := "none"
-	if ok && tlsConn != nil {
-		version := tlsConn.ConnectionState().Version
-		tlsVersion = actualSupportedVersions[version]
-	}
-	h.requestLogger.InfoContext(r.Context(), "request", "host", host, "proto", proto, "requestURL", r.URL, "referrerHeader", referrer, "originHeader", origin, "userAgent", userAgent, "tlsVersion", tlsVersion, "httpVersion", r.Proto)
-	h.inner.ServeHTTP(w, r)
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			host = "0.0.0.0"
+		}
+		if proto == "" {
+			proto = "unknown"
+		}
+		referrer := r.Header.Get("Referer")
+		if referrer == "" {
+			referrer = "noreferrer"
+		}
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			origin = "noorigin"
+		}
+		userAgent := r.Header.Get("User-Agent")
+		if userAgent == "" {
+			userAgent = "nouseragent"
+		}
+		tlsConn, ok := howhttp.SmuggledConn(r.Context())
+		tlsVersion := "none"
+		if ok && tlsConn != nil {
+			version := tlsConn.ConnectionState().Version
+			tlsVersion = actualSupportedVersions[version]
+		}
+		requestLogger.InfoContext(r.Context(), "request",
+			"host", host,
+			"proto", proto,
+			"requestURL", r.URL,
+			"referrerHeader", referrer,
+			"originHeader", origin,
+			"userAgent", userAgent,
+			"tlsVersion", tlsVersion,
+			"httpVersion", r.Proto,
+			"status", metrics.Code,
+			"bytes", metrics.Written,
+			"duration", metrics.Duration,
+		)
+	})
 }
 
 // acmeRedirect is a string that represents the base URL (e.g.

--- a/index_test.go
+++ b/index_test.go
@@ -579,3 +579,44 @@ func TestIndexGoldenPath(t *testing.T) {
 const (
 	expectedJSONBody = `{"given_cipher_suites":["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256","TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256","TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA","TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA","TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA","TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA","TLS_AES_128_GCM_SHA256","TLS_AES_256_GCM_SHA384","TLS_CHACHA20_POLY1305_SHA256"],"given_named_groups":["X25519MLKEM768","SecP256r1MLKEM768","SecP384r1MLKEM1024","x25519","secp256r1","secp384r1","secp521r1"],"given_signature_algorithms":["rsa_pss_rsae_sha256","ecdsa_secp256r1_sha256","ed25519","rsa_pss_rsae_sha384","rsa_pss_rsae_sha512","rsa_pkcs1_sha256","rsa_pkcs1_sha384","rsa_pkcs1_sha512","ecdsa_secp384r1_sha384","ecdsa_secp521r1_sha512"],"post_quantum_key_agreement":true,"ephemeral_keys_supported":true,"session_ticket_supported":false,"tls_compression_supported":false,"unknown_cipher_suite_supported":false,"beast_vuln":false,"able_to_detect_n_minus_one_splitting":false,"insecure_cipher_suites":{},"tls_version":"TLS 1.3","rating":"Probably Okay"}`
 )
+
+func TestLoggingHandlerLogsStatusAndBytes(t *testing.T) {
+	var logged []string
+	var invoked int32
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&invoked, 1)
+		w.WriteHeader(http.StatusTeapot)
+		w.Write([]byte("hello"))
+	})
+	h := loggingHandler(inner, slog.New(slog.NewTextHandler(&capturingWriter{fn: func(s string) { logged = append(logged, s) }}, nil)), "http")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/some/path", nil)
+	req.RemoteAddr = "203.0.113.7:54321"
+	h.ServeHTTP(rec, req)
+
+	if atomic.LoadInt32(&invoked) != 1 {
+		t.Fatalf("inner handler was not invoked exactly once: got %d", invoked)
+	}
+	if rec.Code != http.StatusTeapot {
+		t.Fatalf("status not propagated: got %d", rec.Code)
+	}
+	if len(logged) != 1 {
+		t.Fatalf("expected exactly one log line, got %d: %v", len(logged), logged)
+	}
+	out := logged[0]
+	for _, want := range []string{"msg=request", "status=418", "bytes=5", "proto=http", "host=203.0.113.7"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log line missing %q: %s", want, out)
+		}
+	}
+}
+
+type capturingWriter struct {
+	fn func(string)
+}
+
+func (c *capturingWriter) Write(b []byte) (int, error) {
+	c.fn(string(b))
+	return len(b), nil
+}

--- a/index_test.go
+++ b/index_test.go
@@ -586,7 +586,7 @@ func TestLoggingHandlerLogsStatusAndBytes(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&invoked, 1)
 		w.WriteHeader(http.StatusTeapot)
-		w.Write([]byte("hello"))
+		_, _ = w.Write([]byte("hello"))
 	})
 	h := loggingHandler(inner, slog.New(slog.NewTextHandler(&capturingWriter{fn: func(s string) { logged = append(logged, s) }}, nil)), "http")
 


### PR DESCRIPTION
Replaces the custom `logHandler` struct from #537 with a standard request logging middleware built on `github.com/felixge/httpsnoop`, which is already in the module graph. The middleware captures the response status, bytes written, and duration via httpsnoop's `CaptureMetricsFn` (it tolerates hijacked connections, so we no longer need the Hijack workaround the old TODO mentioned) and emits one structured slog entry per request, now including `status`, `bytes`, and `duration` in addition to the existing fields.

Both call sites in `mux()` and `plaintextMux()` switch from the struct literal to the middleware function, and a test verifies status/bytes propagation and that the inner handler runs.
