### PR TITLE
Document tlsversion.com on the about and API pages

### DIFF
--- a/static/about.html
+++ b/static/about.html
@@ -464,6 +464,20 @@
           given in this section.</p>
 
           <hr />
+
+          <h3 class="fragpadded" id="tlsversion"><a class="anchor-link" href="#tlsversion" aria-label="Link to Just Need Your TLS Version?">#</a>Just Need Your TLS Version?</h3>
+          <p>If all you want to know is the version of TLS your client is
+            using, the preferred way to get it
+            is <a href="https://www.tlsversion.com">tlsversion.com</a>. It's a
+            companion site to How's My SSL? that reports just the TLS version
+            of the client connecting to it, without the full analysis you'll
+            find here.</p>
+          <p>tlsversion.com also has a JSON API for developers
+            at <a href="https://www.tlsversion.com/v1/version.json">https://www.tlsversion.com/v1/version.json</a>.
+            See the <a href="/s/api.html#tlsversion">API page</a> for an
+            example of using it.</p>
+
+          <hr />
           <h3 class="fragpadded" id="tls-vs-ssl"><a class="anchor-link" href="#tls-vs-ssl" aria-label="Link to TLS vs SSL">#</a>TLS vs SSL</h3>
           <p>Okay, last thing. The jargon around this is a little funny, so
           let's be more explicit. The 'S' in "HTTPS" is the TLS protocol. When

--- a/static/api.html
+++ b/static/api.html
@@ -161,6 +161,20 @@
             GitHub</a>. There's a
             <a href="https://github.com/jmhodges/howsmyssl#readme">README</a>.
           </p>
+
+          <h3 id="tlsversion">Just Need the TLS Version?</h3>
+          <p>If all you need is the TLS version of the client, the preferred
+            way to get it
+            is <a href="https://www.tlsversion.com">tlsversion.com</a>. Its
+            JSON API returns just the version, without the rest of the
+            analysis How's My SSL? performs:</p>
+          <p></p><pre>    GET https://www.tlsversion.com/v1/version.json HTTP/1.1
+
+    {
+      "version": "TLS 1.3"
+    }
+
+          </pre><p></p>
         </div>
       </div>
 


### PR DESCRIPTION
## What changed

- **static/about.html**: Added a "Just Need Your TLS Version?" section (anchored at `#tlsversion`, placed right above "TLS vs SSL") that points people who only want their client's TLS version at tlsversion.com and mentions its JSON API.
- **static/api.html**: Added a "Just Need the TLS Version?" section (anchored at `#tlsversion`, linked from the about page) with an example request/response for the tlsversion.com API:

```
GET https://www.tlsversion.com/v1/version.json HTTP/1.1

{
  "version": "TLS 1.3"
}
```

## Why

tlsversion.com is the preferred way to get just the TLS version of a client, without the full analysis How's My SSL? performs. These docs point developers there from both pages.

## Notes for review

- Both new sections follow the existing markup conventions on their pages (the about page's `fragpadded` heading + hover anchor-link style, and the API page's `<pre>` example formatting).
- Verified the pages render and are served correctly by running the server locally.