### PR TITLE
deploy: skip image build and push when the immutable tag already exists

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    env:
+      IMAGE: us-central1-docker.pkg.dev/personal-sites-1295/deploys/howsmyssl
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -35,14 +37,27 @@ jobs:
       - id: gcloud-config-docker
         run: gcloud auth configure-docker -q us-central1-docker.pkg.dev
 
+      # The deploys repository uses immutable tags, so a re-run of this
+      # workflow can't push v1-${GITHUB_SHA} a second time. If the tag already
+      # exists, skip the build and push and deploy the already-pushed image.
+      - id: check-existing-image
+        run: |
+          if gcloud artifacts docker images describe "${IMAGE}:v1-${GITHUB_SHA}" --format='value(image_summary.digest)'; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - id: docker-build
-        run: docker build -t us-central1-docker.pkg.dev/personal-sites-1295/deploys/howsmyssl:v1-${GITHUB_SHA} .
+        if: steps.check-existing-image.outputs.exists == 'false'
+        run: docker build -t "${IMAGE}:v1-${GITHUB_SHA}" .
 
       - id: docker-push
-        run: docker push us-central1-docker.pkg.dev/personal-sites-1295/deploys/howsmyssl:v1-${GITHUB_SHA}
+        if: steps.check-existing-image.outputs.exists == 'false'
+        run: docker push "${IMAGE}:v1-${GITHUB_SHA}"
 
       - id: sha256-of-docker-image
-        run: echo "IMAGE_WITH_SHA256=$(docker inspect --format='{{index .RepoDigests 0}}' us-central1-docker.pkg.dev/personal-sites-1295/deploys/howsmyssl:v1-${GITHUB_SHA})" >> "$GITHUB_OUTPUT"
+        run: echo "IMAGE_WITH_SHA256=${IMAGE}@$(gcloud artifacts docker images describe "${IMAGE}:v1-${GITHUB_SHA}" --format='value(image_summary.digest)')" >> "$GITHUB_OUTPUT"
 
       - id: check-output
         run: echo "found as ${{steps.sha256-of-docker-image.outputs.IMAGE_WITH_SHA256}}"


### PR DESCRIPTION
Re-running the deploy workflow for a commit used to fail at docker push
because the Artifact Registry deploys repository uses immutable tags and
v1-${GITHUB_SHA} already existed. Check for the tag first: if it exists,
skip build and push and resolve its digest from the registry instead of
from the local docker daemon, then deploy that image as before. This
keeps tags immutable while making re-runs idempotent.