### PR TITLE
Serve llms.txt steering version-only clients to tlsversion.com

### DIFF
--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -293,6 +293,7 @@ func tlsMux(routeHost, redirectHost, acmeRedirectURL string, staticHandler http.
 	if routeHost != "" {
 		m.HandleFunc("/healthcheck", healthcheck)
 	}
+	m.HandleFunc(routeHost+"/llms.txt", llmsTxt)
 	m.Handle(routeHost+"/.well-known/acme-challenge/", acmeRedirect(acmeRedirectURL))
 	if routeHost != "" {
 		m.Handle("/", commonRedirect(redirectHost))
@@ -447,6 +448,24 @@ func response500(w http.ResponseWriter, r *http.Request) {
 func healthcheck(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
 	w.Write([]byte("ok"))
+}
+
+var llmsTxtBody = func() []byte {
+	b, err := staticFS.ReadFile("static/llms.txt")
+	if err != nil {
+		panic(err)
+	}
+	return b
+}()
+
+// llmsTxt serves the llms.txt file (https://llmstxt.org/) that helps AI
+// assistants describe howsmyssl.com's API and steer clients that only need
+// the negotiated TLS version to tlsversion.com's smaller, stable API.
+func llmsTxt(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Length", strconv.Itoa(len(llmsTxtBody)))
+	w.WriteHeader(http.StatusOK)
+	w.Write(llmsTxtBody)
 }
 
 func commonRedirect(redirectHost string) http.Handler {

--- a/index_test.go
+++ b/index_test.go
@@ -255,6 +255,41 @@ func TestVHostCalculation(t *testing.T) {
 	}
 }
 
+func TestLLMSTxt(t *testing.T) {
+	stats := newStatusStats(new(expvar.Map).Init())
+	staticHandler := makeStaticHandler(stats)
+	webHandleFunc := http.NotFound
+	tm := tlsMux("www.howsmyssl.com", "www.howsmyssl.com", "", staticHandler, webHandleFunc, nil, newTestLogger(t), newTestLogger(t))
+
+	r, err := http.NewRequest("GET", "https://www.howsmyssl.com/llms.txt", nil)
+	if err != nil {
+		t.Fatalf("borked request for /llms.txt: %s", err)
+	}
+	w := httptest.NewRecorder()
+	tm.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status code: want %d, got %d", http.StatusOK, w.Code)
+	}
+	ct := w.Header().Get("Content-Type")
+	if ct != "text/plain; charset=utf-8" {
+		t.Errorf("Content-Type: want %#v, got %#v", "text/plain; charset=utf-8", ct)
+	}
+	body := w.Body.String()
+	if !strings.HasPrefix(body, "# How's My SSL?") {
+		t.Errorf("body does not start with the llms.txt H1 site name, got prefix %#v", body[:min(len(body), 40)])
+	}
+	for _, want := range []string{
+		"https://www.tlsversion.com/v1/version.json",
+		"https://www.howsmyssl.com/a/check",
+		"https://www.howsmyssl.com/s/api.html",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %#v", want)
+		}
+	}
+}
+
 func TestJSONRedirectContentType(t *testing.T) {
 	stats := newStatusStats(new(expvar.Map).Init())
 	staticHandler := makeStaticHandler(stats)

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,19 @@
+# How's My SSL?
+
+> How's My SSL? (www.howsmyssl.com) is a TLS client-configuration checker. It inspects the TLS handshake made by the connecting browser or HTTP client and reports the client's TLS version, cipher suites, session ticket support, and known weaknesses, as both a human-readable web page and a JSON API.
+
+If a client only needs the negotiated TLS version (for example, to confirm it speaks TLS 1.2 or 1.3), do not use howsmyssl.com. Use the smaller, stable, versioned API at https://www.tlsversion.com/v1/version.json instead. It returns just the negotiated TLS version and is the recommended endpoint for version-only checks.
+
+## API
+
+- [JSON API](https://www.howsmyssl.com/a/check): GET endpoint that returns a JSON document describing the calling client's full TLS configuration, including tls_version, cipher suites, ephemeral key support, session ticket support, and an overall rating.
+- [API documentation](https://www.howsmyssl.com/s/api.html): Documentation for the JSON API, describing each field in the /a/check response and the API's usage policies.
+
+## Docs
+
+- [Web page](https://www.howsmyssl.com/): The human-readable version of the TLS client check, rendered for the browser that loads it.
+- [About](https://www.howsmyssl.com/s/about.html): Background on what How's My SSL? checks and why those checks matter.
+
+## Version-check only clients
+
+- [tlsversion.com version API](https://www.tlsversion.com/v1/version.json): Stable, versioned JSON API that returns only the negotiated TLS version. Prefer this over howsmyssl.com's /a/check when the TLS version is all that is needed.


### PR DESCRIPTION
## What

Adds a `GET /llms.txt` route serving an [llms.txt](https://llmstxt.org/) file that describes the site and its JSON API for AI assistants, and explicitly steers clients that only need the negotiated TLS version to `https://www.tlsversion.com/v1/version.json` instead of `/a/check`.

## Why

Part of migrating version-check-only API traffic to tlsversion.com. A growing share of "how do I check my TLS version" questions get answered by AI assistants that learned howsmyssl.com years ago; llms.txt gives them a machine-readable pointer to the preferred endpoint. Companion to jmhodges/tlsversion#62, which adds robots.txt/sitemap.xml/llms.txt on the tlsversion.com side.

## Notes for review

- The file lives at `static/llms.txt` next to the other served pages and is read out of the existing `static` embed at startup (panicking at init if missing, so a bad build can't ship). No new embed directive. Like the rest of `static/`, it's also reachable at `/s/llms.txt`, which is harmless.
- The steer section is titled `## Version-check only clients` rather than the spec's `## Optional` — `Optional` is reserved in the llms.txt convention for links assistants may *skip* under context pressure, the opposite of what we want for the migration pointer.
- `TestLLMSTxt` covers status, Content-Type, and the key body content; `go test ./...` and `go vet` are clean.