### PR TITLE
Upgrade Go base image from 1.26.5 to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ---- Build stage ----
-FROM golang:1.26.5@sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365 AS build
+FROM golang:1.26.6@sha256:640a234f4bea3e399c056b7b8f9c667c4939befae8db2f14e9785e16eccd4205 AS build
 
 WORKDIR /src
 


### PR DESCRIPTION
## Summary
Updates the Go base image used in the Docker build stage to the latest patch version.

## Changes
- Upgraded Go base image from version 1.26.5 to 1.26.6
- Updated the corresponding image digest to reflect the new version

## Details
This is a routine patch version upgrade of the Go base image used in the Dockerfile's build stage. The new digest ensures the build uses the specific, verified image for Go 1.26.6.