### PR TITLE
Apply the howsmyssl edits to tls1266 and switch consumers to it

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,3 +3,4 @@ name: CodeQL config
 paths-ignore:
   - vendor
   - tls1265
+  - tls1266

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Check gofmt
         run: |
-          unformatted=$(gofmt -l $(git ls-files '*.go' ':!:vendor/*' ':!:tls1265/*'))
+          unformatted=$(gofmt -l $(git ls-files '*.go' ':!:vendor/*' ':!:tls1265/*' ':!:tls1266/*'))
           if [ -n "$unformatted" ]; then
             echo "These files are not gofmt'd:"
             echo "$unformatted"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ client_info.go.
 `go build` will generate a static binary called howsmyssl. This repo is `go
 get`'able, of course.
 
-It has a fork of Go 1.26.5's crypto/tls library at ./tls1265/ in order to expose
+It has a fork of Go 1.26.6's crypto/tls library at ./tls1266/ in order to expose
 the client's ClientHello details (offered cipher suites, compression methods,
 supported versions, curves, and signature algorithms) on the ConnectionState
 struct.

--- a/client_info.go
+++ b/client_info.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	tls "github.com/jmhodges/howsmyssl/tls1265"
+	tls "github.com/jmhodges/howsmyssl/tls1266"
 )
 
 type rating string

--- a/howhttp/conn.go
+++ b/howhttp/conn.go
@@ -1,5 +1,5 @@
 // Package howhttp provides the custom HTTP/1.x and HTTP/2 server plumbing that
-// howsmyssl uses to serve requests over its forked tls1265 stack while still
+// howsmyssl uses to serve requests over its forked tls1266 stack while still
 // reusing net/http and golang.org/x/net/http2.
 package howhttp
 
@@ -15,13 +15,13 @@ import (
 
 	origtls "crypto/tls"
 
-	tls "github.com/jmhodges/howsmyssl/tls1265"
+	tls "github.com/jmhodges/howsmyssl/tls1266"
 )
 
 var (
 	_              net.Listener = &Listener{}
 	_              net.Conn     = &Conn{}
-	errTLSConnConv              = errors.New("unable to convert net.Conn to *tls1265.Conn")
+	errTLSConnConv              = errors.New("unable to convert net.Conn to *tls1266.Conn")
 )
 
 type Listener struct {

--- a/howhttp/conn_internal_test.go
+++ b/howhttp/conn_internal_test.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 	"testing"
 
-	tls "github.com/jmhodges/howsmyssl/tls1265"
+	tls "github.com/jmhodges/howsmyssl/tls1266"
 )
 
 // TestConn_HandshakeFailureCountedOnce locks in the contract that a single

--- a/howhttp/httptest/httptest.go
+++ b/howhttp/httptest/httptest.go
@@ -1,11 +1,11 @@
 // Package howhttptest provides utilities for spinning up a [howhttp.Server]
-// backed by a [tls1265.Listen]er for use in tests, in the style of
+// backed by a [tls1266.Listen]er for use in tests, in the style of
 // [net/http/httptest].
 //
 // Use [NewServer] to start a server bound to 127.0.0.1 with a freshly
 // generated, self-signed certificate. The returned [*Server] exposes a
 // preconfigured [*http.Client] that trusts the generated certificate, plus
-// builders for [*crypto/tls.Config] and [*tls1265.Config] for tests that need
+// builders for [*crypto/tls.Config] and [*tls1266.Config] for tests that need
 // to drive raw TLS connections.
 package howhttptest
 
@@ -23,11 +23,11 @@ import (
 	"time"
 
 	"github.com/jmhodges/howsmyssl/howhttp"
-	tls1265 "github.com/jmhodges/howsmyssl/tls1265"
+	tls1266 "github.com/jmhodges/howsmyssl/tls1266"
 )
 
 // Server is a TLS HTTP server listening on a random localhost port, serving
-// over a [tls1265.Listen]er wrapped by [howhttp.NewListener] and a
+// over a [tls1266.Listen]er wrapped by [howhttp.NewListener] and a
 // [howhttp.Server]. It is the howhttp equivalent of
 // [net/http/httptest.Server].
 //
@@ -36,11 +36,11 @@ import (
 type Server struct {
 	// URL is the base URL ("https://127.0.0.1:PORT") clients should target.
 	URL string
-	// Listener is the [howhttp.NewListener]-wrapped tls1265 listener that the
+	// Listener is the [howhttp.NewListener]-wrapped tls1266 listener that the
 	// server is accepting on.
 	Listener net.Listener
-	// TLS is the [tls1265.Config] the server is using.
-	TLS *tls1265.Config
+	// TLS is the [tls1266.Config] the server is using.
+	TLS *tls1266.Config
 	// Config is the underlying [howhttp.Server].
 	Config *howhttp.Server
 
@@ -70,8 +70,8 @@ func NewServer(handler http.Handler) *Server {
 	rootCAs := x509.NewCertPool()
 	rootCAs.AddCert(leaf)
 
-	tlsConf := &tls1265.Config{
-		Certificates: []tls1265.Certificate{{
+	tlsConf := &tls1266.Config{
+		Certificates: []tls1266.Certificate{{
 			Certificate: [][]byte{certDER},
 			PrivateKey:  key,
 			Leaf:        leaf,
@@ -79,7 +79,7 @@ func NewServer(handler http.Handler) *Server {
 		NextProtos: []string{"h2", "http/1.1"},
 	}
 
-	nl, err := tls1265.Listen("tcp", "127.0.0.1:0", tlsConf)
+	nl, err := tls1266.Listen("tcp", "127.0.0.1:0", tlsConf)
 	if err != nil {
 		panic(fmt.Errorf("howhttptest: listen: %w", err))
 	}
@@ -159,7 +159,7 @@ func (s *Server) Certificate() *x509.Certificate { return s.leafCert }
 
 // RootCAs returns the [*x509.CertPool] containing the server's leaf
 // certificate. The same pool can be assigned to either a [*crypto/tls.Config]
-// or a [*tls1265.Config], since both use the same [crypto/x509] type.
+// or a [*tls1266.Config], since both use the same [crypto/x509] type.
 func (s *Server) RootCAs() *x509.CertPool { return s.rootCAs }
 
 // ClientTLSConfig returns a fresh [*crypto/tls.Config] that trusts the
@@ -173,12 +173,12 @@ func (s *Server) ClientTLSConfig() *origtls.Config {
 	}
 }
 
-// ClientTLS1265Config returns a fresh [*tls1265.Config] that trusts the
+// ClientTLS1266Config returns a fresh [*tls1266.Config] that trusts the
 // server's certificate. Useful for tests that need to drive a raw
-// [tls1265.Dial]-style client. The returned value may be freely mutated by
+// [tls1266.Dial]-style client. The returned value may be freely mutated by
 // the caller.
-func (s *Server) ClientTLS1265Config() *tls1265.Config {
-	return &tls1265.Config{
+func (s *Server) ClientTLS1266Config() *tls1266.Config {
+	return &tls1266.Config{
 		RootCAs:    s.rootCAs,
 		ServerName: "127.0.0.1",
 		NextProtos: []string{"h2", "http/1.1"},

--- a/howhttp/httptest/httptest_test.go
+++ b/howhttp/httptest/httptest_test.go
@@ -21,7 +21,7 @@ func TestServer_CertificateAndRootCAs(t *testing.T) {
 	if srv.ClientTLSConfig().RootCAs != srv.RootCAs() {
 		t.Error("ClientTLSConfig().RootCAs != RootCAs()")
 	}
-	if srv.ClientTLS1265Config().RootCAs != srv.RootCAs() {
-		t.Error("ClientTLS1265Config().RootCAs != RootCAs()")
+	if srv.ClientTLS1266Config().RootCAs != srv.RootCAs() {
+		t.Error("ClientTLS1266Config().RootCAs != RootCAs()")
 	}
 }

--- a/howhttp/server.go
+++ b/howhttp/server.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"time"
 
-	tls1265 "github.com/jmhodges/howsmyssl/tls1265"
+	tls1266 "github.com/jmhodges/howsmyssl/tls1266"
 	"golang.org/x/net/http2"
 )
 
@@ -24,20 +24,20 @@ func (k *contextKey) String() string { return "howhttp context value " + k.name 
 // out to handlers that need to investigate the client's TLS settings.
 var smuggledConnKey = &contextKey{"smuggledConn"}
 
-// SmuggledConn returns the underlying *tls1265.Conn that was attached to the
+// SmuggledConn returns the underlying *tls1266.Conn that was attached to the
 // request's context.
-func SmuggledConn(ctx context.Context) (*tls1265.Conn, bool) {
-	tc, ok := ctx.Value(smuggledConnKey).(*tls1265.Conn)
+func SmuggledConn(ctx context.Context) (*tls1266.Conn, bool) {
+	tc, ok := ctx.Value(smuggledConnKey).(*tls1266.Conn)
 	return tc, ok
 }
 
 // addTLSConnToContext is suitable for use as http.Server.ConnContext. It pulls
-// the underlying *tls1265.Conn out of a *Conn and stashes it on the context for
+// the underlying *tls1266.Conn out of a *Conn and stashes it on the context for
 // handlers to retrieve via SmuggledConn.
 //
 // We do this smuggling instead of using http.Hijacker.Hijack to avoid needing
 // to do a bunch of connection management and HTTP response formatting
-// ourselves. We smuggle the whole *tls1265.Conn into the context instead of
+// ourselves. We smuggle the whole *tls1266.Conn into the context instead of
 // just its ConnectionState because the handshake may not yet be performed, and
 // we don't want to lock here waiting for the handshake to finish.
 func addTLSConnToContext(ctx context.Context, c net.Conn) context.Context {
@@ -92,7 +92,7 @@ type Server struct {
 
 // NewServer creates a new Server with the given listener and handler. The
 // listener is expected to be a *Listener, or, at least, a listener created
-// with tls1265.Listen.
+// with tls1266.Listen.
 func NewServer(listener net.Listener, handler http.Handler) (*Server, error) {
 	h1 := &http.Server{
 		Handler:           handler,

--- a/howhttp/server_internal_test.go
+++ b/howhttp/server_internal_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	tls "github.com/jmhodges/howsmyssl/tls1265"
+	tls "github.com/jmhodges/howsmyssl/tls1266"
 	"golang.org/x/net/http2"
 )
 

--- a/howhttp/smoke_test.go
+++ b/howhttp/smoke_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/jmhodges/howsmyssl/howhttp"
 	howhttptest "github.com/jmhodges/howsmyssl/howhttp/httptest"
-	tls1265 "github.com/jmhodges/howsmyssl/tls1265"
+	tls1266 "github.com/jmhodges/howsmyssl/tls1266"
 )
 
 func TestServer_HTTP11(t *testing.T) {
@@ -84,17 +84,17 @@ func TestServer_SmuggledConnReachable(t *testing.T) {
 	}
 }
 
-func TestServer_RawTLS1265Client(t *testing.T) {
+func TestServer_RawTLS1266Client(t *testing.T) {
 	srv := howhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, "raw")
 	}))
 	defer srv.Close()
 
-	conf := srv.ClientTLS1265Config()
+	conf := srv.ClientTLS1266Config()
 	conf.NextProtos = []string{"http/1.1"}
 
 	addr := strings.TrimPrefix(srv.URL, "https://")
-	c, err := tls1265.Dial("tcp", addr, conf)
+	c, err := tls1266.Dial("tcp", addr, conf)
 	if err != nil {
 		t.Fatalf("Dial: %s", err)
 	}

--- a/howsmyssl.go
+++ b/howsmyssl.go
@@ -29,7 +29,7 @@ import (
 	"cloud.google.com/go/logging"
 	"github.com/jmhodges/howsmyssl/gzip"
 	"github.com/jmhodges/howsmyssl/howhttp"
-	tls "github.com/jmhodges/howsmyssl/tls1265"
+	tls "github.com/jmhodges/howsmyssl/tls1266"
 	"google.golang.org/api/option"
 )
 

--- a/reloader.go
+++ b/reloader.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	tls "github.com/jmhodges/howsmyssl/tls1265"
+	tls "github.com/jmhodges/howsmyssl/tls1266"
 )
 
 func newKeypairReloader(certPath, keyPath string) (*keypairReloader, error) {

--- a/tls1266/common.go
+++ b/tls1266/common.go
@@ -312,6 +312,16 @@ type ConnectionState struct {
 	// resumed connections that don't support Extended Master Secret (RFC 7627).
 	TLSUnique []byte
 
+	// Added for howsmyssl's use
+	ClientCipherSuites               []uint16
+	CompressionMethods               []uint8
+	NMinusOneRecordSplittingDetected bool
+	AbleToDetectNMinusOneSplitting   bool
+	SessionTicketsSupported          bool
+	SupportedVersions                []uint16
+	SupportedCurves                  []CurveID
+	SupportedSignatureAlgorithms     []SignatureScheme
+
 	// ECHAccepted indicates if Encrypted Client Hello was offered by the client
 	// and accepted by the server. Currently, ECH is supported only on the
 	// client side.
@@ -811,6 +821,16 @@ type Config struct {
 	// them, set CurvePreferences explicitly or use either the
 	// GODEBUG=tlsmlkem=0 or the GODEBUG=tlssecpmlkem=0 environment variable.
 	CurvePreferences []CurveID
+
+	// Added for howsmyssl's use.
+	//
+	// SignatureAlgorithms, if non-nil, overrides the contents of the
+	// signature_algorithms extension (13) the client sends in its ClientHello.
+	// The list is written verbatim — no filtering by TLS version or FIPS mode
+	// — so callers can exercise GREASE values, draft codepoints, and
+	// otherwise-disabled schemes. Setting this on a server Config has no
+	// effect.
+	SignatureAlgorithms []SignatureScheme
 
 	// DynamicRecordSizingDisabled disables adaptive sizing of TLS records.
 	// When true, the largest possible TLS record size is always used. When

--- a/tls1266/conn.go
+++ b/tls1266/conn.go
@@ -121,6 +121,12 @@ type Conn struct {
 	activeCall atomic.Int32
 
 	tmp [16]byte
+
+	// Added for howsmyssl's use
+	clientHello                      *clientHelloMsg
+	ableToDetectNMinusOneSplitting   bool
+	readOneAppDataRecord             bool
+	nMinusOneRecordSplittingDetected bool
 }
 
 // Access to net.Conn methods.
@@ -699,6 +705,21 @@ func (c *Conn) readRecordOrCCS(expectChangeCipherSpec bool) error {
 	if (typ == recordTypeApplicationData || (typ == recordTypeHandshake && !handshakeComplete)) && len(data) > 0 {
 		// This is a state-advancing message: reset the retry count.
 		c.retryCount = 0
+	}
+
+	// Added for howsmyssl's use
+	//
+	// This detects BEAST mitigation when the first app data record is
+	// of length 1 or 0. Length 1 mitigation is common in web browsers, while
+	// length 0 is common in OpenSSL tools. Since the requests to
+	// /a/check are typically very small, this won't detect the Java
+	// style BEAST mitigation where the 1 byte record is sent after
+	// the first application record but only if its large enough.
+	//
+	// TODO(jmhodges): check that 1 or 0 byte records are sent between others
+	if !c.readOneAppDataRecord && c.ableToDetectNMinusOneSplitting && typ == recordTypeApplicationData {
+		c.readOneAppDataRecord = true
+		c.nMinusOneRecordSplittingDetected = len(data) == 1 || len(data) == 0
 	}
 
 	// Handshake messages MUST NOT be interleaved with other record types in TLS 1.3.
@@ -1649,6 +1670,21 @@ func (c *Conn) connectionStateLocked() ConnectionState {
 	} else {
 		state.ekm = c.ekm
 	}
+	// Added for howsmyssl's use
+	if c.clientHello != nil {
+		state.ClientCipherSuites = make([]uint16, len(c.clientHello.cipherSuites))
+		copy(state.ClientCipherSuites, c.clientHello.cipherSuites)
+		state.CompressionMethods = make([]uint8, len(c.clientHello.compressionMethods))
+		copy(state.CompressionMethods, c.clientHello.compressionMethods)
+		state.SessionTicketsSupported = c.clientHello.ticketSupported
+		state.SupportedVersions = c.clientHello.supportedVersions
+		state.SupportedCurves = make([]CurveID, len(c.clientHello.supportedCurves))
+		copy(state.SupportedCurves, c.clientHello.supportedCurves)
+		state.SupportedSignatureAlgorithms = make([]SignatureScheme, len(c.clientHello.supportedSignatureAlgorithms))
+		copy(state.SupportedSignatureAlgorithms, c.clientHello.supportedSignatureAlgorithms)
+	}
+	state.AbleToDetectNMinusOneSplitting = c.ableToDetectNMinusOneSplitting
+	state.NMinusOneRecordSplittingDetected = c.nMinusOneRecordSplittingDetected
 	state.ECHAccepted = c.echAccepted
 	return state
 }

--- a/tls1266/handshake_client.go
+++ b/tls1266/handshake_client.go
@@ -119,7 +119,12 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCli
 	}
 
 	if maxVersion >= VersionTLS12 {
-		hello.supportedSignatureAlgorithms = supportedSignatureAlgorithms(minVersion)
+		// Added for howsmyssl's use
+		if config.SignatureAlgorithms != nil {
+			hello.supportedSignatureAlgorithms = slices.Clone(config.SignatureAlgorithms)
+		} else {
+			hello.supportedSignatureAlgorithms = supportedSignatureAlgorithms(minVersion)
+		}
 		hello.supportedSignatureAlgorithmsCert = supportedSignatureAlgorithmsCert()
 	}
 

--- a/tls1266/handshake_server.go
+++ b/tls1266/handshake_server.go
@@ -44,6 +44,8 @@ func (c *Conn) serverHandshake(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Added for howsmyssl's use
+	c.clientHello = clientHello
 
 	if c.vers == VersionTLS13 {
 		hs := serverHandshakeStateTLS13{
@@ -74,6 +76,14 @@ func (hs *serverHandshakeState) handshake() error {
 	c.buffering = true
 	if err := hs.checkForResumption(); err != nil {
 		return err
+	}
+	// Added for howsmyssl's use
+	//
+	// Disallow resumption when client is at TLS 1.0 or below so that
+	// we can be sure the checks for HasBeastVulnSuites is set
+	// correctly. A latency and CPU hit, but tolerable for accuracy.
+	if c.vers <= VersionTLS10 {
+		hs.sessionState = nil
 	}
 	if hs.sessionState != nil {
 		// The client has included a session ticket and so we do an abbreviated handshake.
@@ -395,6 +405,26 @@ func supportsECDHE(c *Config, version uint16, supportedCurves []CurveID, support
 
 func (hs *serverHandshakeState) pickCipherSuite() error {
 	c := hs.c
+
+	// Added for howsmyssl's use
+	//
+	// For TLS 1.0 clients, try to select a CBC cipher for BEAST detection.
+	if c.vers <= VersionTLS10 {
+		beastSuites := []uint16{TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_CBC_SHA256}
+		for _, cs := range hs.clientHello.cipherSuites {
+			for _, bs := range beastSuites {
+				if cs == bs {
+					candidate := selectCipherSuite([]uint16{cs}, c.config.cipherSuites(false), hs.cipherSuiteOk)
+					if candidate != nil {
+						hs.suite = candidate
+						c.cipherSuite = candidate.id
+						c.ableToDetectNMinusOneSplitting = true
+						return nil
+					}
+				}
+			}
+		}
+	}
 
 	preferenceList := c.config.cipherSuites(isAESGCMPreferred(hs.clientHello.cipherSuites))
 

--- a/tls_test.go
+++ b/tls_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/jmhodges/howsmyssl/howhttp"
-	tls "github.com/jmhodges/howsmyssl/tls1265"
+	tls "github.com/jmhodges/howsmyssl/tls1266"
 	ztls "github.com/zmap/zcrypto/tls"
 	zx509 "github.com/zmap/zcrypto/x509"
 )


### PR DESCRIPTION
Third of four PRs bumping the vendored `crypto/tls` fork to Go 1.26.6.

**Stacked on #1115**, which is stacked on #1118 — review those first. This
PR's base is #1115's branch, so the diff here is just the feature work.

This is **Bucket B**: the actual reason the fork exists. It re-applies the
howsmyssl edits to the freshly ported package and moves the consumers over in
the same change, since the consumers are what exercise the new fields.

## Feature edits (B1–B5)

* `ConnectionState` gains the ClientHello fields (offered cipher suites,
  compression methods, session-ticket support, supported
  versions/curves/signature algorithms) and the two BEAST-splitting flags;
  `Config` gains the client-side `SignatureAlgorithms` override.
* `Conn` captures the ClientHello, records whether the first application-data
  record was 0 or 1 bytes — the fingerprint of 1/n-1 BEAST mitigation — and
  copies both into `ConnectionState`.
* The server stashes the ClientHello, refuses resumption at TLS 1.0 and below
  so the full-handshake cipher-selection path always runs, and prefers a
  client-offered CBC suite there so the splitting check is meaningful.
* The client writes `Config.SignatureAlgorithms` verbatim when set, so callers
  can exercise GREASE values and otherwise-disabled schemes.

All nine hunks were located by the grep the doc prescribes, which #1118 made
trustworthy, and all nine carry the marker forward into `tls1266`: two in
`common.go`, three in `conn.go`, one in `handshake_client.go`, three in
`handshake_server.go`.

## Consumers

Renamed every reference off the old package — import paths and aliases in
`client_info.go`, `howsmyssl.go`, `reloader.go`, `tls_test.go`, and throughout
`howhttp/` and `howhttp/httptest/`, plus the derived identifier
`ClientTLS1265Config` → `ClientTLS1266Config` and the doc comments. The README's
fork line and the gofmt and CodeQL path exclusions now cover `tls1266`; the old
exclusions stay until #1117 deletes the old package, so there's no window where
either path is unguarded.

`tls1265` is still present and now unused. It is removed in #1117.

## Verification

`go build ./...`, `go vet ./...`, `go test -race ./...`, and the CI gofmt check
all pass. The howsmyssl tests cover BEAST detectability and the
signature-algorithms override, so a green run here is the real validation of the
port.

Interaction check on the two pieces of new upstream code, since both land near
fork edits:

* The rewritten `retryCount` conditional in `conn.go` sits immediately above the
  BEAST-detection block. It only decides when the retry counter resets — it
  doesn't consume `data`, change `typ`, or return — and the detection block
  still runs before the `recordTypeApplicationData` branch drops 0-byte records
  via `retryReadRecord`, so OpenSSL-style 0-byte mitigation is still observed
  and latched. Detection semantics are unchanged.
* The `fips140ems` knob reads through the vendored `godebug` stub, which keeps
  FIPS EMS enforcement on, matching upstream's default. The only capability lost
  is disabling it via GODEBUG, which is the intended tradeoff of the stub.
