### PR TITLE
Mark every Bucket B hunk in tls1265 and sharpen the forking doc

### DIFF
--- a/docs/FORKING_CRYPTO_TLS.md
+++ b/docs/FORKING_CRYPTO_TLS.md
@@ -296,7 +296,9 @@ forks coexist between PRs; nothing imports the new package until PR 2 lands.
 
 1. Re-apply the feature edits **B1–B5** to the new package. The fastest way
    to find the anchor points is `grep -rn "Added for howsmyssl's use"
-   tls1262/` in the *previous* fork and port each hunk.
+   tls<old>/` in the *previous* fork and port each hunk. Every Bucket B hunk
+   carries that marker — nine of them — so if the count drops, an edit was
+   lost.
 2. Update the consumers. Don't rely on a fixed file list — grep the repo for
    the old package name (`grep -rn "tls<old>\|TLS<old>" --include="*.go" .`,
    excluding the fork directory itself and `vendor/`) and rename every hit:
@@ -348,7 +350,7 @@ matching upstream toolchain:
 
 ```sh
 UP="$(go env GOROOT)/src/crypto/tls"     # with GOTOOLCHAIN=goX.Y.Z
-for f in tls1262/*.go; do
+for f in tls<ver>/*.go; do
     b=$(basename "$f")
     diff "$UP/$b" "$f"    # every hunk should be an import rewrite or a
                           # "// Added for howsmyssl's use" block

--- a/tls1265/conn.go
+++ b/tls1265/conn.go
@@ -707,6 +707,8 @@ func (c *Conn) readRecordOrCCS(expectChangeCipherSpec bool) error {
 		c.retryCount = 0
 	}
 
+	// Added for howsmyssl's use
+	//
 	// This detects BEAST mitigation when the first app data record is
 	// of length 1 or 0. Length 1 mitigation is common in web browsers, while
 	// length 0 is common in OpenSSL tools. Since the requests to
@@ -1668,6 +1670,7 @@ func (c *Conn) connectionStateLocked() ConnectionState {
 	} else {
 		state.ekm = c.ekm
 	}
+	// Added for howsmyssl's use
 	if c.clientHello != nil {
 		state.ClientCipherSuites = make([]uint16, len(c.clientHello.cipherSuites))
 		copy(state.ClientCipherSuites, c.clientHello.cipherSuites)

--- a/tls1265/handshake_client.go
+++ b/tls1265/handshake_client.go
@@ -119,6 +119,7 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCli
 	}
 
 	if maxVersion >= VersionTLS12 {
+		// Added for howsmyssl's use
 		if config.SignatureAlgorithms != nil {
 			hello.supportedSignatureAlgorithms = slices.Clone(config.SignatureAlgorithms)
 		} else {

--- a/tls1265/handshake_server.go
+++ b/tls1265/handshake_server.go
@@ -44,6 +44,7 @@ func (c *Conn) serverHandshake(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Added for howsmyssl's use
 	c.clientHello = clientHello
 
 	if c.vers == VersionTLS13 {
@@ -76,6 +77,8 @@ func (hs *serverHandshakeState) handshake() error {
 	if err := hs.checkForResumption(); err != nil {
 		return err
 	}
+	// Added for howsmyssl's use
+	//
 	// Disallow resumption when client is at TLS 1.0 or below so that
 	// we can be sure the checks for HasBeastVulnSuites is set
 	// correctly. A latency and CPU hit, but tolerable for accuracy.
@@ -403,6 +406,8 @@ func supportsECDHE(c *Config, version uint16, supportedCurves []CurveID, support
 func (hs *serverHandshakeState) pickCipherSuite() error {
 	c := hs.c
 
+	// Added for howsmyssl's use
+	//
 	// For TLS 1.0 clients, try to select a CBC cipher for BEAST detection.
 	if c.vers <= VersionTLS10 {
 		beastSuites := []uint16{TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_CBC_SHA256}


### PR DESCRIPTION
Groundwork for the Go 1.26.6 fork bump. The three port PRs (#1115, #1116,
#1117) are stacked on this one.

## The problem

`docs/FORKING_CRYPTO_TLS.md` claims that every howsmyssl feature edit in the
fork carries an `// Added for howsmyssl's use` comment, and tells the next
porter to find them with `grep -rn "Added for howsmyssl's use"`. That was only
true of the struct fields. These six hunks had no marker:

* `conn.go` — the 1/n-1 record-splitting detection in the record-read path
* `conn.go` — the ClientHello copy into `ConnectionState`
* `handshake_server.go` — stashing the ClientHello on the `Conn`
* `handshake_server.go` — disabling resumption at TLS 1.0 and below
* `handshake_server.go` — the CBC suite preference in `pickCipherSuite`
* `handshake_client.go` — the `Config.SignatureAlgorithms` override

So the documented grep found three of nine hunks, and a port that followed the
doc would have silently dropped the other six — including all of the BEAST
detection this fork exists for.

## The change

Adds the six missing markers to `tls1265`. Comment-only: no statement changes,
`gofmt` clean, `go build`, `go vet`, and `go test -race` all pass.

Also updates the doc to state the expected marker count (nine), so a future port
can tell when an edit has gone missing rather than discovering it in production,
and to point the grep and diff-verify recipes at `tls<old>` and `tls<ver>`
rather than the long-gone `tls1262`.

Nothing here is specific to the 1.26.6 bump — that version's porting notes live
in #1115, the PR that performs it.

Marking `tls1265` rather than only the new `tls1266` is deliberate: it makes the
doc's grep true of the fork a porter would actually be copying from, and it
keeps this fix useful even if the version bump stalls.
