### PR TITLE
Pin the load balancer IP and spread pods across nodes

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -38,6 +38,21 @@ spec:
         version: "1"
     spec:
       terminationGracePeriodSeconds: 45
+      # Prefer to put each replica on a different node so one node going away
+      # (an upgrade, an auto-repair, a zonal network blip) doesn't take every
+      # pod with it. This is a preference, not a requirement: the dg cluster is
+      # small and node-auto-provisioned, and a hard requirement would leave
+      # rolling-update surge pods Pending when there's no free node to satisfy
+      # it, which is the stuck-rollout failure mode we've already hit once.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: howsmyssl
       containers:
         - name: howsmyssl
           image: __IMAGE__
@@ -105,6 +120,13 @@ spec:
   # the LoadBalancer passes both ports straight through. The www.howsmyssl.com
   # DNS record points at this service's external IP.
   type: LoadBalancer
+  # This is the reserved address google_compute_address.howsmyssl-lb in the
+  # founding repo's ops/gcp/main.tf. It has been this Service's IP since 2020,
+  # but until now nothing in this file said so, and the only thing keeping it
+  # was that `kubectl apply` leaves alone fields it has never managed. Pinning
+  # it here means a recreated Service gets the same IP instead of a fresh one
+  # that DNS doesn't point at. If it changes there, change it here too.
+  loadBalancerIP: 34.71.45.200
   selector:
     app: howsmyssl
     status: ok


### PR DESCRIPTION
Follow-up from the 2026-09-01 outage, which lines up with Google's us-central1 network incident (J5ia5t9p3g9Q5Wi7r8Ev) rather than anything that changed in this repo or the cluster. Neither change here would have prevented a zonal network fault, but both were latent problems that showed up while debugging it.

**Pin `spec.loadBalancerIP`.** The Service has used 34.71.45.200 since 2020 and the address is reserved as `google_compute_address.howsmyssl-lb` in the founding repo, whose comment says this Service pins it. It didn't. The only thing preserving it was that `kubectl apply` leaves alone fields it has never managed. Declaring it means a recreated Service keeps the IP that DNS points at. The GCE controller sees the desired IP already matches the forwarding rule, so applying this is a no-op on the live LB. Same pattern tlsversion already uses.

**Preferred pod anti-affinity on hostname.** With no spread rule, all three replicas can sit on one node in a cluster this small, and one node event takes the whole site down. This is `preferred`, not `required`, on purpose: node auto-provisioning is capped low and a hard rule would leave rolling-update surge pods Pending with no node to satisfy it, which is the stuck-rollout failure that darkishgreen/founding#1423 was about.

Deploys to prod on merge via the existing workflow; expect a normal rolling update since the pod template changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dh4Jj9DywtYR58Z5bGJx2e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh4Jj9DywtYR58Z5bGJx2e)_